### PR TITLE
imapserver.py: fix __xoauth2handler in Python 3

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -243,7 +243,7 @@ class IMAPServer():
             socket.socket = self.authproxied_socket
             try:
                 response = urllib.request.urlopen(
-                    self.oauth2_request_url, urllib.parse.urlencode(params)).read()
+                    self.oauth2_request_url, urllib.parse.urlencode(params).encode('utf-8')).read()
             except Exception as e:
                 try:
                     msg = "%s (configuration is: %s)" % (e, str(params))


### PR DESCRIPTION
### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested: tested on Python 3.7

### References

- N/A

### Additional information

Error when using the XOAUTH2 token refresh logic:

  ("POST data should be bytes, an iterable of bytes, or a file object. It cannot be of type str. (configuration is: {....}", <traceback object at 0x7fc6e69f2b40>)
     ['  File ".../offlineimap3/offlineimap/accounts.py", line 298, in syncrunner
        self.__sync()
    ', '  File ".../offlineimap3/offlineimap/accounts.py", line 374, in __sync
        remoterepos.getfolders()
    ', '  File ".../offlineimap3/offlineimap/repository/IMAP.py", line 446, in getfolders
        imapobj = self.imapserver.acquireconnection()
    ', '  File ".../offlineimap3/offlineimap/imapserver.py", line 579, in acquireconnection
        self.__authn_helper(imapobj)
    ', '  File ".../offlineimap3/offlineimap/imapserver.py", line 443, in __authn_helper
        if func(imapobj):
    ', '  File ".../offlineimap3/offlineimap/imapserver.py", line 377, in __authn_xoauth2
        imapobj.authenticate(\'XOAUTH2\', self.__xoauth2handler)
    ', '  File ".../offlineimap3/venv/lib/python3.7/site-packages/imaplib2.py", line 681, in authenticate
        typ, dat = self._simple_command(\'AUTHENTICATE\', mechanism.upper())
    ', '  File ".../offlineimap3/venv/lib/python3.7/site-packages/imaplib2.py", line 1674, in _simple_command
        return self._command_complete(self._command(name, *args), kw)
    ', '  File ".../offlineimap3/venv/lib/python3.7/site-packages/imaplib2.py", line 1394, in _command
        literal = literator(data, rqb)
    ', '  File ".../offlineimap3/venv/lib/python3.7/site-packages/imaplib2.py", line 2237, in process
        ret = self.mech(self.decode(data))
    ', '  File ".../offlineimap3/offlineimap/imapserver.py", line 253, in __xoauth2handler
        raise type(e)(msg, exc_info()[2])
    ']

Fix by encoding the data passed to urllib.

Signed-off-by: Thomas De Schampheleire <thomas.de_schampheleire@nokia.com>
