### PR TITLE
Using isinstance instead type

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -482,7 +482,7 @@ class IMAPFolder(BaseFolder):
                              item[1], flags=re.IGNORECASE):
                     found = item[0]
             elif found is not None:
-                if type(item) == type(b""):
+                if isinstance(item, bytes):
                     item = item.decode('utf-8')
                     uid = re.search("UID\s+(\d+)", item, flags=re.IGNORECASE)
                     if uid:


### PR DESCRIPTION
This patch uses isinstance, like Thomas pointed in their last commit.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

No issues

### Additional information


