### PR TITLE
imaplib expect bytes in the append

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -666,7 +666,7 @@ class IMAPFolder(BaseFolder):
                 # Do the APPEND.
                 try:
                     (typ, dat) = imapobj.append(self.getfullIMAPname(),
-                                                imaputil.flagsmaildir2imap(flags), date, content)
+                                                imaputil.flagsmaildir2imap(flags), date, bytes(content, 'utf-8'))
                     # This should only catch 'NO' responses since append()
                     # will raise an exception for 'BAD' responses:
                     if typ != 'OK':


### PR DESCRIPTION
imaplib2 is doing this code for strings:

        if isinstance(message, str):
            message = bytes(message, 'ASCII')

But our message is already encoded using 'utf-8'.
Then, we can set the message as bytes, encoded using 'utf-8'
in offlineimap and imaplib2 won't change our message.

This patch solves this problem:

WARNING:OfflineImap:
Traceback:
  File "/home/kix/src/offlineimap3/offlineimap/folder/Base.py", line 1127, in syncmessagesto
    action(dstfolder, statusfolder)
  File "/home/kix/src/offlineimap3/offlineimap/folder/Base.py", line 955, in __syncmessagesto_copy
    self.copymessageto(uid, dstfolder, statusfolder, register=0)
  File "/home/kix/src/offlineimap3/offlineimap/folder/Base.py", line 855, in copymessageto
    new_uid = dstfolder.savemessage(uid, message, flags, rtime)
  File "/home/kix/src/offlineimap3/offlineimap/folder/IMAP.py", line 668, in savemessage
    (typ, dat) = imapobj.append(self.getfullIMAPname(),
  File "/usr/lib/python3/dist-packages/imaplib2.py", line 660, in append
    message = bytes(message, 'ASCII')

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


