### PR TITLE
Use system sslcacertfile by default

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -233,13 +233,15 @@ class IMAPRepository(BaseRepository):
     def getsslcacertfile(self):
         """Determines CA bundle.
 
-        Returns path to the CA bundle.  It is either explicitely specified
-        or requested via "OS-DEFAULT" value (and we will search known
-        locations for the current OS and distribution).
+        Returns path to the CA bundle.  It is explicitely specified or
+        requested via "OS-DEFAULT" value (and we will search known
+        locations for the current OS and distribution). If it is not
+        specified, we will search it in the known locations.
 
-        If search via "OS-DEFAULT" route yields nothing, we will throw an
-        exception to make our callers distinguish between not specified
-        value and non-existent default CA bundle.
+        If search route, via "OS-DEFAULT" or because is not specified,
+        yields nothing, we will throw an exception to make our callers
+        distinguish between not specified value and non-existent
+        default CA bundle.
 
         It is also an error to specify non-existent file via configuration:
         it will error out later, but, perhaps, with less verbose explanation,
@@ -250,7 +252,10 @@ class IMAPRepository(BaseRepository):
         xforms = [os.path.expanduser, os.path.expandvars, os.path.abspath]
         cacertfile = self.getconf_xform('sslcacertfile', xforms, None)
         # Can't use above cacertfile because of abspath.
-        if self.getconf('sslcacertfile', None) == "OS-DEFAULT":
+        conf_sslacertfile = self.getconf('sslcacertfile', None)
+        if conf_sslacertfile == "OS-DEFAULT" or \
+            conf_sslacertfile == None or \
+            conf_sslacertfile == '':
             cacertfile = get_os_sslcertfile()
             if cacertfile is None:
                 searchpath = get_os_sslcertfile_searchpath()


### PR DESCRIPTION
This patch includes a new functionality to get the sslcacertfile.

With this patch is possible to remove the sslcacertfile variable form the
.offlineimaprc and use the system's default. This could be easy for new users.

With this patch, the user can use ssl without the sslcacertfile option
in .offlineimaprc, use sslcacertfile = <empty> (no include anything
after the equal sign, os specify the sslcacertfile as previosly.

Currently, these are the options:

    User specifies sslacertfile -> OK
    User specifies sslacertfile=OS-DEFAULT
        If the system's default is provided -> OK
        If the system's default is not provided -> Fail
    User do not specifies sslacertfile -> Fail
    User specifies empty sslacertfile -> Fail

With the new option (this patch).

    User specifies sslacertfile -> OK
    User specifies sslacertfile=OS-DEFAULT or
    User do not specifies sslacertfile or
    User specifies empty sslacertfile
        If the system's default is provided -> OK
        If the system's default is not provided -> Fail

Closes #14

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


