### PR TITLE
Updated cram-md5 authentication

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -16,6 +16,7 @@
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
 import datetime
+import hashlib
 import hmac
 import socket
 import json
@@ -184,7 +185,9 @@ class IMAPServer():
         self.ui.debug('imap', '__md5handler: got challenge %s' % challenge)
 
         passwd = self.__getpassword()
-        retval = self.username + ' ' + hmac.new(passwd, challenge).hexdigest()
+        retval = self.username + ' ' +\
+                 hmac.new(bytes(passwd, encoding='utf-8'), challenge,
+                          digestmod=hashlib.md5).hexdigest()
         self.ui.debug('imap', '__md5handler: returning %s' % retval)
         return retval
 


### PR DESCRIPTION
This patch updates the cram-md5 auth. We include two steps:

- Convert the password variable from string to bytes. This change is
  because in Python2 strings and bytes are the same, but not in Python3
- Updates the call to hmac.new, now the digestmod argument is mandatory.
  I used hashlib.md5, because we need md5 hash.

Closes #19

    Signed-off-by: Rodolfo García Peñas (kix) <kix@kix.es>

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [ ] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [ ] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


