### PR TITLE
BUGs related with issue #16

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -150,6 +150,7 @@ class IMAPFolder(BaseFolder):
         # messages or the UID of the last message have changed.  Otherwise
         # only flag changes could have occurred.
         retry = True  # Should we attempt another round or exit?
+        imapdata = None
         while retry:
             retry = False
             imapobj = self.imapserver.acquireconnection()
@@ -759,7 +760,10 @@ class IMAPFolder(BaseFolder):
                                  "appending a message. Got: %s." % str(resp))
                     return 0
                 try:
-                    uid = int(resp[-1].split(' ')[1])
+                    # Convert the UID from [b'4 1532'] to ['4 1532']
+                    s_uid = [x.decode('utf-8') for x in resp]
+                    # Now, read the UID field
+                    uid = int(s_uid[-1].split(' ')[1])
                 except ValueError:
                     uid = 0  # Definetly not what we should have.
                 except Exception:

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -595,7 +595,9 @@ class IMAPServer:
             # update capabilities after login, e.g. gmail serves different ones
             typ, dat = imapobj.capability()
             if dat != [None]:
-                imapobj.capabilities = tuple(dat[-1].upper().split())
+                # Get the capabilities and convert them to string from bytes
+                s_dat = [x.decode('utf-8') for x in dat[-1].upper().split()]
+                imapobj.capabilities = tuple(s_dat)
 
             if self.delim is None:
                 listres = imapobj.list(self.reference, '""')[1]


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #16 

### Additional information

I uploaded this patch set. There are three patches:

- IMAP.py split long lines: Is only style patch. No important things.
- BUG: Support for server capabilities
  - We need convert the response list of bytes in response list of strings, else we are not using the response!
- BUG: Read response as string from APPENDUID
  - We need convert the response list of bytes in response list of strings, else we are not using the response!
  - imapdata = None is only to remove a warning. I should include it in other patch, but is not a real problem here.


