### PR TITLE
Include imaplib debug and avoid crash in search without results

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -238,7 +238,7 @@ class IMAPFolder(BaseFolder):
 
             # Then, I can do the check in the same way than Python 2
             # with string comparison:
-            if ' ' in res_data[0] or res_data[0] == '':
+            if len(res_data) > 0 and (' ' in res_data[0] or res_data[0] == ''):
                 res_data = res_data[0].split()
             # Some servers are broken.
             if 0 in res_data:

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -515,6 +515,10 @@ class IMAPServer:
         curThread = currentThread()
         imapobj = None
 
+        imap_debug = 0
+        if 'imap' in self.ui.debuglist:
+            imap_debug = 5
+
         if len(self.availableconnections):  # One is available.
             # Try to find one that previously belonged to this thread
             # as an optimization.  Start from the back since that's where
@@ -547,6 +551,7 @@ class IMAPServer:
                     imapobj = imaplibutil.IMAP4_Tunnel(
                         self.tunnel,
                         timeout=socket.getdefaulttimeout(),
+                        debug=imap_debug,
                         use_socket=self.proxied_socket,
                     )
                     success = True
@@ -563,6 +568,7 @@ class IMAPServer:
                         ca_certs=self.sslcacertfile,
                         cert_verify_cb=self.__verifycert,
                         ssl_version=self.sslversion,
+                        debug=imap_debug,
                         timeout=socket.getdefaulttimeout(),
                         fingerprint=self.fingerprint,
                         use_socket=self.proxied_socket,
@@ -576,6 +582,7 @@ class IMAPServer:
                         self.hostname, self.port,
                         timeout=socket.getdefaulttimeout(),
                         use_socket=self.proxied_socket,
+                        debug=imap_debug,
                         af=self.af,
                     )
 


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

I am including imaplib debug in one patch (I removed migrating from python 2 to python 3) and include a check in the search.

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).
