### PR TITLE
foldersort broken with instance comparison

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -720,6 +720,24 @@ class IMAPRepository(BaseRepository):
                         return mycmp(self.obj.getvisiblename(),
                                      other.obj.getvisiblename())
 
+                    def __lt__(self, other):
+                        return self.__cmp__(other) < 0
+
+                    def __le__(self, other):
+                        return self.__cmp__(other) <= 0
+
+                    def __gt__(self, other):
+                        return self.__cmp__(other) > 0
+
+                    def __ge__(self, other):
+                        return self.__cmp__(other) >= 0
+
+                    def __eq__(self, other):
+                        return self.__cmp__(other) == 0
+
+                    def __ne__(self, other):
+                        return self.__cmp__(other) != 0
+
                 return K
 
             retval.sort(key=cmp2key(self.foldersort))


### PR DESCRIPTION
This patch solves a problem about the comparison of mails used in
foldersort.

When foldersort is used, for example with:

 lambda x,y: -cmp(x,y)

The user gets an error:

ERROR: While attempting to sync account 'accountname'
  '<' not supported between instances of 'K' and 'K'

Traceback:
  File "offlineimap3/offlineimap/accounts.py", line 298, in syncrunner
    self.__sync()
  File "offlineimap3/offlineimap/accounts.py", line 374, in __sync
    remoterepos.getfolders()
  File "offlineimap3/offlineimap/repository/IMAP.py", line 725, in getfolders
    retval.sort(key=cmp2key(self.foldersort))

The problem is because in Python 3, we must specify all parameters for
total_ordering (see https://docs.python.org/3/library/functools.html in
the functools.total_ordering block):

  Given a class defining one or more rich comparison ordering methods,
  this class decorator supplies the rest. This simplifies the effort
  involved in specifying all of the possible rich comparison operations:

  The class must define one of __lt __(), __le __(), __gt __(), or __ge __().
  In addition, the class should supply an __eq __() method.

Also, see: https://docs.python.org/3.1/library/stdtypes.html#comparisons

  Instances of a class cannot be ordered with respect to other instances
  of the same class, or other types of object, unless the class defines
  enough of the methods __lt __(), __le __(), __gt __(), and __ge __()
  (in general, __lt __() and __eq __() are sufficient, if you want the
  conventional meanings of the comparison operators).

This patch implements all methods.

Closes #33

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #33 


