### PR TITLE
imapserver: GSSAPI: make sure reply is all bytes

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -310,12 +310,8 @@ class IMAPServer:
             # This is a behavior we got from pykerberos.  First byte is one,
             # first four bytes are preserved (pykerberos calls this a length).
             # Any additional bytes are username.
-            reply = []
-            reply[0:4] = response.message[0:4]
-            reply[0] = '\x01'
-            if self.username:
-                reply[5:] = self.username
-            reply = ''.join(reply)
+            reply = b'\x01' + response.message[1:4]
+            reply += bytes(self.username, 'utf-8')
 
             response = self.gss_vc.wrap(reply, response.encrypted)
             return response.message if response.message else ""


### PR DESCRIPTION
The current code mixed string and bytes leading to:

ERROR: Exceptions occurred during the run!
ERROR: While attempting to sync account 'honk.sigxcpu.org'
  sequence item 1: expected str instance, int found

Traceback:
  File "/usr/share/offlineimap3/offlineimap/accounts.py", line 298, in syncrunner
    self.__sync()
  File "/usr/share/offlineimap3/offlineimap/accounts.py", line 374, in __sync
    remoterepos.getfolders()
  File "/usr/share/offlineimap3/offlineimap/repository/IMAP.py", line 648, in getfolders
    imapobj = self.imapserver.acquireconnection()
  File "/usr/share/offlineimap3/offlineimap/imapserver.py", line 592, in acquireconnection
    self.__authn_helper(imapobj)
  File "/usr/share/offlineimap3/offlineimap/imapserver.py", line 449, in __authn_helper
    if func(imapobj):
  File "/usr/share/offlineimap3/offlineimap/imapserver.py", line 362, in __authn_gssapi
    imapobj.authenticate('GSSAPI', self.__gsshandler)
  File "/usr/lib/python3/dist-packages/imaplib2.py", line 691, in authenticate
    typ, dat = self._simple_command('AUTHENTICATE', mechanism.upper())
  File "/usr/lib/python3/dist-packages/imaplib2.py", line 1684, in _simple_command
    return self._command_complete(self._command(name, *args), kw)
  File "/usr/lib/python3/dist-packages/imaplib2.py", line 1404, in _command
    literal = literator(data, rqb)
  File "/usr/lib/python3/dist-packages/imaplib2.py", line 2247, in process
    ret = self.mech(self.decode(data))
  File "/usr/share/offlineimap3/offlineimap/imapserver.py", line 318, in __gsshandler
    reply = ''.join(reply)

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).
   Ran against my GSSAPI dovecot 2.3.4.1

### References

- Issue #no_space

### Additional information


