### PR TITLE
BUG: Right format for username using remoteusereval

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -206,12 +206,23 @@ class IMAPRepository(BaseRepository):
         Returns: Returns the remoteusereval or remoteuser or netrc user value.
 
         """
-        localeval = self.localeval
-
         if self.config.has_option(self.getsection(), 'remoteusereval'):
             user = self.getconf('remoteusereval')
             if user is not None:
-                return localeval.eval(user).encode('UTF-8')
+                l_user = self.localeval.eval(user)
+
+                # We need a str username
+                if isinstance(l_user, bytes):
+                    return l_user.decode(encoding='utf-8')
+                elif isinstance(l_user, str):
+                    return l_user
+
+                # If is not bytes or str, we have a problem
+                raise OfflineImapError("Could not get a right username format for"
+                                       " repository %s. Type found: %s. "
+                                       "Please, open a bug." %
+                                       (self.name, type(l_user)),
+                                       OfflineImapError.ERROR.FOLDER)
 
         if self.config.has_option(self.getsection(), 'remoteuser'):
             # Assume the configuration file to be UTF-8 encoded so we must not


### PR DESCRIPTION
### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #21
- Pull Request #22

### Additional information

Similarly to 7a4285370f338a6653e8bb1a8fb99e3703683b6f, reading the username
using remoteusereval returns a bytes objects instead an utf-8 string.

This patch includes support for both string and bytes objects.
