### PR TITLE
Included charset detection

### DIFF
--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -20,9 +20,11 @@ import socket
 import time
 import re
 import os
+from pathlib import Path
 from sys import exc_info
 from threading import Lock
 from hashlib import md5
+import chardet
 from offlineimap import OfflineImapError, emailutil
 from .Base import BaseFolder
 
@@ -256,11 +258,18 @@ class MaildirFolder(BaseFolder):
     def getmessage(self, uid):
         """Return the content of the message."""
 
+        # TODO: Perhaps, force the encoding using config file
         filename = self.messagelist[uid]['filename']
         filepath = os.path.join(self.getfullname(), filename)
-        file = open(filepath, 'rt')
-        retval = file.read()
-        file.close()
+        # Open the file as binary and read it
+        file = Path(filepath)
+        blob = file.read_bytes()
+        # Detect the encoding
+        detection = chardet.detect(blob)
+        encoding = detection["encoding"]
+        # Read the file as text
+        retval = blob.decode(encoding)
+
         # TODO: WHY are we replacing \r\n with \n here? And why do we
         #      read it as text?
         return retval.replace("\r\n", "\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ gssapi[kerberos]
 portalocker[cygwin]
 rfc6555
 distro
+
+imaplib2~=3.5
+urllib3~=1.25.9
+certifi~=2020.6.20
+chardet~=3.0.4


### PR DESCRIPTION
This patch includes charset detection to read the message.

This patch is related to issue #43

Signed-off-by: Rodolfo García Peñas (kix) <kix@kix.es>

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #43

### Additional information


