### PR TITLE
Reference secure/HTTPS pages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Upstream status (`master` branch):
 Upstream status (`next` branch):
 [![OfflineIMAP build status on Travis-CI.org](https://travis-ci.org/OfflineIMAP/offlineimap.svg?branch=next)](https://travis-ci.org/OfflineIMAP/offlineimap)
 
-[offlineimap]: http://github.com/OfflineIMAP/offlineimap
-[website]: http://www.offlineimap.org
-[wiki]: http://github.com/OfflineIMAP/offlineimap/wiki
-[blog]: http://www.offlineimap.org/posts.html
+[offlineimap]: https://github.com/OfflineIMAP/offlineimap
+[website]: https://www.offlineimap.org
+[wiki]: https://github.com/OfflineIMAP/offlineimap/wiki
+[blog]: https://www.offlineimap.org/posts.html
 
 Links:
 * Official github code repository: [offlineimap]


### PR DESCRIPTION
Use TLS-enabled URIs (s/http:/https:/)

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


