### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Upstream status (`next` branch):
 [![OfflineIMAP build status on Travis-CI.org](https://travis-ci.org/OfflineIMAP/offlineimap.svg?branch=next)](https://travis-ci.org/OfflineIMAP/offlineimap)
 
 [offlineimap]: http://github.com/OfflineIMAP/offlineimap
+[offlineimap3]: https://github.com/OfflineIMAP/offlineimap3
 [website]: http://www.offlineimap.org
 [wiki]: http://github.com/OfflineIMAP/offlineimap/wiki
 [blog]: http://www.offlineimap.org/posts.html


### PR DESCRIPTION
Add URL for "offlineimap3" links

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


