### PR TITLE
Encoding edge cases

### DIFF
--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -26,6 +26,7 @@ from email import policy
 from email.parser import BytesParser
 from email.generator import BytesGenerator
 from email.utils import parsedate_tz, mktime_tz
+from email.errors import NoBoundaryInMultipartDefect
 
 from offlineimap import threadutil
 from offlineimap.ui import getglobalui

--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -26,7 +26,6 @@ from email import policy
 from email.parser import BytesParser
 from email.generator import BytesGenerator
 from email.utils import parsedate_tz, mktime_tz
-from email.errors import NoBoundaryInMultipartDefect
 
 from offlineimap import threadutil
 from offlineimap.ui import getglobalui

--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -735,10 +735,8 @@ class IMAPFolder(BaseFolder):
                         raise OfflineImapError(
                             "Saving msg (%s) in folder '%s', "
                             "repository '%s' failed (abort). "
-                            "Server responded: %s\n"
-                            "Message content was: %s" %
-                            (msg_id, self, self.getrepository(),
-                             str(e), dbg_output),
+                            "Server responded: %s\n" %
+                            (msg_id, self, self.getrepository(), str(e)),
                             OfflineImapError.ERROR.MESSAGE,
                             exc_info()[2])
 
@@ -752,10 +750,8 @@ class IMAPFolder(BaseFolder):
                     imapobj = None
                     raise OfflineImapError(
                         "Saving msg (%s) folder '%s', repo '%s'"
-                        "failed (error). Server responded: %s\n"
-                        "Message content was: %s" %
-                        (msg_id, self, self.getrepository(),
-                         str(e), dbg_output),
+                        "failed (error). Server responded: %s\n" %
+                        (msg_id, self, self.getrepository(), str(e)),
                         OfflineImapError.ERROR.MESSAGE,
                         exc_info()[2])
 

--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -25,6 +25,7 @@ from threading import Lock
 from hashlib import md5
 from offlineimap import OfflineImapError
 from .Base import BaseFolder
+from email.errors import NoBoundaryInMultipartDefect
 
 # Find the UID in a message filename
 re_uidmatch = re.compile(',U=(\d+)')
@@ -297,24 +298,29 @@ class MaildirFolder(BaseFolder):
         filename = self.messagelist[uid]['filename']
         filepath = os.path.join(self.getfullname(), filename)
         fd = open(filepath, 'rb')
-        retval = self.parser['8bit'].parse(fd)
-        try:
-            if len(retval.defects) > 0:
-                ui.warn("Message has defects: {}".format(retval.defects))
-                # See if the defects are preventing us from obtaining bytes and
-                # handle known issues
-                _ = retval.as_bytes(policy=self.policy['8bit'])
-        except UnicodeEncodeError as err:
-            if any(isinstance(defect, NoBoundaryInMultipartDefect) for defect in retval.defects):
-                # (Hopefully) Rare instance where multipart boundary is not
-                # properly quoted.  Solve by fixing the boundary and parsing
-                fd.seek(0)
-                _buffer = fd.read()
-                retval = self.parser['8bit'].parsebytes(_quote_boundary_fix(_buffer))
-            else:
-                # Unknown issue which is causing failure of as_bytes()
-                ui.warn("Message has defects preventing it from being processed!")
+        _fd_bytes = fd.read()
         fd.close()
+        retval = self.parser['8bit'].parsebytes(_fd_bytes)
+        if len(retval.defects) > 0:
+            # We don't automatically apply fixes as to attempt to preserve the original message
+            self.ui.warn("UID {} has defects: {}".format(uid, retval.defects))
+            if any(isinstance(defect, NoBoundaryInMultipartDefect) for defect in retval.defects):
+                # (Hopefully) Rare defect from a broken client where multipart boundary is
+                # not properly quoted.  Attempt to solve by fixing the boundary and parsing
+                self.ui.warn(" ... applying multipart boundary fix.")
+                retval = self.parser['8bit'].parsebytes(self._quote_boundary_fix(_fd_bytes))
+            try:
+                # See if the defects after fixes are preventing us from obtaining bytes
+                _ = retval.as_bytes(policy=self.policy['8bit'])
+            except UnicodeEncodeError as err:
+                # Unknown issue which is causing failure of as_bytes()
+                msg_id = self.getmessageheader(retval, "message-id")
+                if msg_id is None:
+                    msg_id = '<unknown-message-id>'
+                raise OfflineImapError(
+                        "UID {} ({}) has defects preventing it from being processed!\n  {}: {}".format(
+                            uid, msg_id, type(err).__name__, err),
+                        OfflineImapError.ERROR.MESSAGE)
         return retval
 
     # Interface from BaseFolder

--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -299,7 +299,11 @@ class MaildirFolder(BaseFolder):
         fd = open(filepath, 'rb')
         retval = self.parser['8bit'].parse(fd)
         try:
-            _ = retval.as_bytes(policy=self.policy['8bit'])
+            if len(retval.defects) > 0:
+                ui.warn("Message has defects: {}".format(retval.defects))
+                # See if the defects are preventing us from obtaining bytes and
+                # handle known issues
+                _ = retval.as_bytes(policy=self.policy['8bit'])
         except UnicodeEncodeError as err:
             if any(isinstance(defect, NoBoundaryInMultipartDefect) for defect in retval.defects):
                 # (Hopefully) Rare instance where multipart boundary is not

--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -243,13 +243,14 @@ class MaildirFolder(BaseFolder):
         # quoted boundaries.
         try: boundary_field = \
             re.search(b"content-type:.*(boundary=[\"]?[A-Za-z0-9'()+_,-./:=? ]+[\"]?)",
-            re.split(b'[\r]?\n[\r]?\n',raw_msg_bytes)[0],re.IGNORECASE).group(1)
+              re.split(b'[\r]?\n[\r]?\n', raw_msg_bytes)[0],
+              (re.IGNORECASE|re.DOTALL)).group(1)
         except AttributeError:
             # No match
             return raw_msg_bytes
         # get the boundary field, and strip off any trailing ws (against RFC rules, leading ws is OK)
         # if it was already quoted, well then there was nothing to fix
-        boundary, value = boundary_field.split(b'=',1)
+        boundary, value = boundary_field.split(b'=', 1)
         value = value.rstrip()
         # ord(b'"') == 34
         if value[0] == value[-1] == 34:
@@ -260,8 +261,8 @@ class MaildirFolder(BaseFolder):
             # boundary="ahahah  " as the email library will trim the ws for us
             return raw_msg_bytes
         else:
-            new_field = b''.join([boundary,b'="',value,b'"'])
-            return(raw_msg_bytes.replace(boundary_field,new_field,1))
+            new_field = b''.join([boundary, b'="', value, b'"'])
+            return(raw_msg_bytes.replace(boundary_field, new_field, 1))
 
 
     # Interface from BaseFolder

--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -225,6 +225,44 @@ class MaildirFolder(BaseFolder):
                         retval[uid] = date_excludees[uid]
         return retval
 
+    def _quote_boundary_fix(self, raw_msg_bytes):
+        """Modify a raw message to quote the boundary separator for multipart messages.
+
+        This function quotes only the first occurrence of the boundary field in
+        the email header, and quotes any boundary value.  Improperly quoted
+        boundary fields can give the internal python email library issues.
+
+        :returns: The raw byte stream containing the quoted boundary
+        """
+        # Use re.split to extract just the header, and search for the boundary in
+        # the context-type header and extract just the boundary and characters per
+        # RFC 2046 ( see https://tools.ietf.org/html/rfc2046#section-5.1.1 )
+        # We don't cap the length to 70 characters, because we are just trying to
+        # soft fix this message to resolve the python library looking for properly
+        # quoted boundaries.
+        try: boundary_field = \
+            re.search(b"content-type:.*(boundary=[\"]?[A-Za-z0-9'()+_,-./:=? ]*[\"]?)",
+            re.split(b'[\r]?\n[\r]?\n',raw_msg_bytes)[0],re.IGNORECASE).group(1)
+        except AttributeError:
+            # No match
+            return raw_msg_bytes
+        # get the boundary field, and strip off any trailing ws (against RFC rules, leading ws is OK)
+        # if it was already quoted, well then there was nothing to fix
+        boundary, value = boundary_field.split(b'=',1)
+        value = value.rstrip()
+        # ord(b'"') == 34
+        if value[0] == value[-1] == 34:
+            # Sanity Check - Do not requote if already quoted.
+            # A quoted boundary was the end goal so return the original
+            #
+            # No need to worry about if the original email did something like:
+            # boundary="ahahah  " as the email library will trim the ws for us
+            return raw_msg_bytes
+        else:
+            new_field = b''.join([boundary,b'="',value,b'"'])
+            return(raw_msg_bytes.replace(boundary_field,new_field,1))
+
+
     # Interface from BaseFolder
     def quickchanged(self, statusfolder):
         """Returns True if the Maildir has changed
@@ -260,6 +298,18 @@ class MaildirFolder(BaseFolder):
         filepath = os.path.join(self.getfullname(), filename)
         fd = open(filepath, 'rb')
         retval = self.parser['8bit'].parse(fd)
+        try:
+            _ = retval.as_bytes(policy=self.policy['8bit'])
+        except UnicodeEncodeError as err:
+            if any(isinstance(defect, NoBoundaryInMultipartDefect) for defect in retval.defects):
+                # (Hopefully) Rare instance where multipart boundary is not
+                # properly quoted.  Solve by fixing the boundary and parsing
+                fd.seek(0)
+                _buffer = fd.read()
+                retval = self.parser['8bit'].parsebytes(_quote_boundary_fix(_buffer))
+            else:
+                # Unknown issue which is causing failure of as_bytes()
+                ui.warn("Message has defects preventing it from being processed!")
         fd.close()
         return retval
 

--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -241,7 +241,7 @@ class MaildirFolder(BaseFolder):
         # soft fix this message to resolve the python library looking for properly
         # quoted boundaries.
         try: boundary_field = \
-            re.search(b"content-type:.*(boundary=[\"]?[A-Za-z0-9'()+_,-./:=? ]*[\"]?)",
+            re.search(b"content-type:.*(boundary=[\"]?[A-Za-z0-9'()+_,-./:=? ]+[\"]?)",
             re.split(b'[\r]?\n[\r]?\n',raw_msg_bytes)[0],re.IGNORECASE).group(1)
         except AttributeError:
             # No match


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #62
- PR #56 

### Additional information

Changes to `offlineimap/folder/IMAP.py` are to correct a bug introduced with PR #56 that will occur if the server is not reachable and debugging is _not_ enabled (and thus dbg_output is undefined).  Since message-id is more useful to better pin point the correct message, it seemed better to remove dbg_output in this failure case (instead of introducing more logic to construct it).

Changes to `offlineimap/folder/Maildir.py` are to correct Issue #62.  It does this by parsing the message and determining if it has any defects.  If the list of defects contain NoBoundaryInMultipartDefect, a function is run on the raw binary of the file to attempt to quote the multipart boundary.  re.DOTALL was used in case the context-type is folded.  I ran a series of checks on the correction script, with the following test cases (output shown is `original --> corrected`):
```
b'Content-Type: multipart/mixed; boundary===--12345--12345--12345--==' --> b'Content-Type: multipart/mixed; boundary="==--12345--12345--12345--=="'
b'Content-Type: multipart/mixed; boundary= hello there? ' --> b'Content-Type: multipart/mixed; boundary=" hello there?"'
b'Content-Type: multipart/mixed; boundary=1234567890' --> b'Content-Type: multipart/mixed; boundary="1234567890"'
b'Content-Type: multipart/mixed; boundary=1234567890/abcdefg' --> b'Content-Type: multipart/mixed; boundary="1234567890/abcdefg"'
b'Content-Type: multipart/mixed; boundary="==--12345--12345--12345--=="' --> b'Content-Type: multipart/mixed; boundary="==--12345--12345--12345--=="'
b'Content-Type: multipart/mixed; boundary="0123456789012345678901234567890123456789012345678901234567890123456789"' --> b'Content-Type: multipart/mixed; boundary="0123456789012345678901234567890123456789012345678901234567890123456789"'
b'Content-Type: multipart/mixed; boundary=0123456789012345678901234567890123456789012345678901234567890123456789ABC' --> b'Content-Type: multipart/mixed; boundary="0123456789012345678901234567890123456789012345678901234567890123456789ABC"'
b'Content-Type: multipart/mixed; boundary="oh no "' --> b'Content-Type: multipart/mixed; boundary="oh no "'
b"Content-Type: multipart/mixed; boundary=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'()+_,-./:= ?" --> b'Content-Type: multipart/mixed; boundary="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\'()+_,-./:= ?"'
b'Content-Type: multipart/mixed; boundary=' --> b'Content-Type: multipart/mixed; boundary='
b'Content-Type: multipart/mixed; boundary=1' --> b'Content-Type: multipart/mixed; boundary="1"'
b'Content-Type: \n  multipart/mixed; \n  boundary=1' --> b'Content-Type: \n  multipart/mixed; \n  boundary="1"'
b"Content-Type: multipart/mixed; \n  boundary=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'()+_,-./:= ?" --> b'Content-Type: multipart/mixed; \n  boundary="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\'()+_,-./:= ?"'
```
This is a minimal change to these erred messages that will allow the email library to parse the message where it can be retrieved with an `as_bytes()` call.  I believe the current issue may be a Python bug, where policy is ignored when the NoBoundaryInMultipartDefect is encountered.  A bug as been submitted to the Python team for review: https://bugs.python.org/issue43818

If there is still an encoding error after detecting the defects and applying the boundary fix, it is now caught, and a message is logged with the message-id.  This should also prevent offlineimap from stopping one such a message is encountered.  The result looking like:
```
OfflineIMAP 7.3.0
  Licensed under the GNU GPL v2 or any later version (with an OpenSSL exception)
imaplib2 v3.05, Python v3.8.5, OpenSSL 1.1.1f  31 Mar 2020
Account sync TEST:
 *** Processing account TEST
 Establishing connection to localhost:1143 (RemoteDavmail)
Folder Test [acc: TEST]:
 Syncing Test: IMAP -> Maildir
 Copy message UID -2 (1/2) LocalMail:Test -> RemoteDavmail:Test
 UID -2 has defects: [NoBoundaryInMultipartDefect(), MultipartInvariantViolationDefect()]
  ... applying multipart boundary fix.
 ERROR: UID -2 (<abc123@hostname>) has defects preventing it from being processed!
  UnicodeEncodeError: 'ascii' codec can't encode characters in position 276-277: ordinal not in range(128)
 Copy message UID -1 (2/2) LocalMail:Test -> RemoteDavmail:Test
 UID -1 has defects: [NoBoundaryInMultipartDefect(), MultipartInvariantViolationDefect()]
  ... applying multipart boundary fix.
Account sync TEST:
 *** Finished account 'TEST' in 0:08
ERROR: Exceptions occurred during the run!
ERROR: UID -2 (<abc123@hostname>) has defects preventing it from being processed!
  UnicodeEncodeError: 'ascii' codec can't encode characters in position 276-277: ordinal not in range(128)
```
Here message with UID -2 fails because it is intentionally broken beyond repair (no boundaries).  Message with UID -1 is the message found in Issue #62 and is copied to the server.



