### PR TITLE
Fix hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Links:
 
 ***"Get the emails where you need them."***
 
-[Official offlineimap][offlineimap3].
+[Official offlineimap][https://github.com/OfflineIMAP/offlineimap3].
 
 
 ## Description


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR
Fixed hyperlink to the project's github page in README.

> Add character x `[x]`.

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.



