### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Upstream status (`next` branch):
 [blog]: https://www.offlineimap.org/posts.html
 
 Links:
-* Official github code repository: [offlineimap]
+* Official github code repository
+  * for Python 2: [offlineimap]
+  * for Python 3: [offlineimap3]
 * Website: [website]
 * Wiki: [wiki]
 * Blog: [blog]
@@ -22,13 +24,12 @@ Links:
 
 ***"Get the emails where you need them."***
 
-[Official offlineimap][https://github.com/OfflineIMAP/offlineimap3].
-
 
 ## Description
 
 OfflineIMAP is software that downloads your email mailbox(es) as **local
 Maildirs**. OfflineIMAP will synchronize both sides via *IMAP*.
+
 
 ## Why should I use OfflineIMAP?
 
@@ -61,11 +62,11 @@ GNU General Public License v2.
 You should first check if your distribution already packages OfflineIMAP for you.
 Downloads releases as [tarball or zipball](https://github.com/OfflineIMAP/offlineimap3/tags).
 
-If you are running Linux Os, you can install offlineimap with:
+If you are running Linux, you can install offlineimap with:
 
 -  openSUSE `zypper in offlineimap`
--  Arch Linux `pacman -S offlineimap`
 -  fedora `dnf install offlineimap`
+-  Arch Linux: through AUR package [offlineimap3-git](https://aur.archlinux.org/packages/offlineimap3-git/)
 
 ## Feedbacks and contributions
 
@@ -98,9 +99,6 @@ Bugs, issues and contributions can be requested to both the mailing list or the
 * Python v3+
 * rfc6555 (required)
 * imaplib2 >= 3.5
-  * If you encounter an error that `cannot import name 'IMAP4' from 'imaplib2'`, it means that you need to install imaplib2 from the git repository.
-  * First, clone https://github.com/jazzband/imaplib2.git to your local computer.
-  * Then, enter the directory of the repository, run `pip install .` or `pip install --user .`.
 * gssapi (optional), for Kerberos authentication
 * portalocker (optional), if you need to run offlineimap in Cygwin for Windows
 


### PR DESCRIPTION
- moved hyperlinks to the same section
- removed redundant and incorectly-formated Markdown hyperlink
- added the information of offlineimap 3 Arch Linux AUR package
- removed info of installing imaplib2 from its github repo: imaplib2 now
  has a release on PyPI.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- The modification in README that addresses issue #69 has been removed in this PR because it's not needed anymore.

### Additional information


