### PR TITLE
offlineimap.conf: oauth returned values must be str

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -939,7 +939,7 @@ remoteuser = username
 #oauth2_client_id = YOUR_CLIENT_ID
 #oauth2_client_secret = YOUR_CLIENT_SECRET
 #
-# The return values must be bytes.
+# The return values must be str.
 #oauth2_client_id_eval = get_client_id("accountname")
 #oauth2_client_secret_eval = get_client_secret("accountname")
 #
@@ -971,7 +971,7 @@ remoteuser = username
 #oauth2_request_url = https://accounts.google.com/o/oauth2/token
 #oauth2_refresh_token = REFRESH_TOKEN
 #
-# The returned values must be bytes.
+# The returned values must be str.
 #oauth2_access_token_eval = get_access_token("accountname")
 #oauth2_refresh_token_eval = get_refresh_token("accountname")
 


### PR DESCRIPTION
Fixes #57.

Signed-off-by: Nicolas Sebrecht <nicolas.s-dev@laposte.net>
