### PR TITLE
Allow create and delete folders with spaces

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -772,6 +772,10 @@ class IMAPRepository(BaseRepository):
     def deletefolder(self, foldername):
         """Delete a folder on the IMAP server."""
 
+        # Folder names with spaces requires quotes
+        if ' ' in foldername:
+            foldername = '"' + foldername + '"'
+
         if self.account.utf_8_support:
             foldername = imaputil.utf8_IMAP(foldername)
         imapobj = self.imapserver.acquireconnection()
@@ -833,6 +837,10 @@ class IMAPRepository(BaseRepository):
             return
         imapobj = self.imapserver.acquireconnection()
         try:
+            # Folder names with spaces requires quotes
+            if ' ' in foldername:
+                foldername = '"' + foldername + '"'
+
             if self.account.utf_8_support:
                 foldername = imaputil.utf8_IMAP(foldername)
 


### PR DESCRIPTION
This patch adds support to create and delete folders with the space
character.

When the folder includes spaces, all the folder name must be quoted.

Close: #58

Signed-off-by: Rodolfo García Peñas (kix) <kix@kix.es>

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #58 

### Additional information


