### PR TITLE
 BUG: Right format for host using remotehosteval

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -141,7 +141,21 @@ class IMAPRepository(BaseRepository):
         if self.config.has_option(self.getsection(), 'remotehosteval'):
             host = self.getconf('remotehosteval')
             try:
-                host = self.localeval.eval(host)
+                l_host = self.localeval.eval(host)
+
+                # We need a str host
+                if isinstance(l_host, bytes):
+                    return l_host.decode(encoding='utf-8')
+                elif isinstance(l_host, str):
+                    return l_host
+
+                # If is not bytes or str, we have a problem
+                raise OfflineImapError("Could not get a right host format for"
+                                       " repository %s. Type found: %s. "
+                                       "Please, open a bug." %
+                                       (self.name, type(l_host)),
+                                       OfflineImapError.ERROR.FOLDER)
+
             except Exception as exc:
                 raise OfflineImapError(
                     "remotehosteval option for repository "


### PR DESCRIPTION
Similarly to 7a428537, reading the host
using remotehosteval returns a bytes objects instead an utf-8 string.

This patch includes support for both string and bytes objects.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Pull Requests: https://github.com/OfflineIMAP/offlineimap3/pull/22
- Pull Requests: https://github.com/OfflineIMAP/offlineimap3/pull/50

### Additional information

Similarly to 7a42853, reading the host
using remotehosteval returns a bytes objects instead an utf-8 string.

This patch includes support for both string and bytes objects.
