### PR TITLE
Draft: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3 as base
+
+MAINTAINER Ben Yanke <benyanke@gmail.com>
+
+##############
+# Main setup stage
+##############
+
+# Copy in deps first, to improve build caching
+COPY requirements.txt /app-src/requirements.txt
+WORKDIR /app-src
+
+# Get kerberos deps before pip deps can be fetched
+#RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y krb5-user -y && rm -rf /var/lib/apt/lists/*
+
+# Get latest pip and dependencies
+RUN /usr/local/bin/python3 -m pip install --upgrade pip && pip install -r requirements.txt
+
+# Copy in rest of the code after deps are in place
+COPY . /app-src
+
+# Install the app
+RUN /usr/local/bin/python3 setup.py install
+
+##############
+# Run tests in a throwaway stage
+# if tests are added later, run them here
+##############
+#FROM base as test
+#WORKDIR /app-src
+#RUN /usr/local/bin/python3 setup.py test
+
+##############
+# Throw away the test stage, revert back to base stage before push
+##############
+
+FROM base
+WORKDIR /root
+CMD ["/usr/local/bin/offlineimap"]
+# reads from /root/.offlineimaprc by default - mount this in for running

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ If you are running Linux, you can install offlineimap with:
 -  openSUSE `zypper in offlineimap`
 -  fedora `dnf install offlineimap`
 -  Arch Linux: through AUR package [offlineimap3-git](https://aur.archlinux.org/packages/offlineimap3-git/)
+-  Docker image: `offlineimap/offlineimap:latest` 
+ (note: image not published yet, just an example)
 
 ## Feedbacks and contributions
 


### PR DESCRIPTION
Discussed in https://github.com/OfflineIMAP/offlineimap/issues/701

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### Additional information

This PR adds a minimal dockerfile to provide a docker container for this project.

This serves as the the base for building, but a hosting platform needs to be decided upon and setup for providing images during release. That could be a discussion outside the scope of this PR, however.

To test the build, checkout the repo, and from the repo root, run `docker build -t offlineimap .` which then builds a local offline imap container.

```bash
me@here:dir/to/project $ docker build  .
Sending build context to Docker daemon  12.45MB
Step 1/10 : FROM python:3 as base
 ---> f112835c8a07
Step 2/10 : MAINTAINER Ben Yanke <benyanke@gmail.com>
 ---> Using cache
[...]
Step 10/10 : CMD ["/usr/local/bin/offlineimap"]
 ---> Running in bb0a8439a92c
Removing intermediate container bb0a8439a92c
 ---> a0de4946268e
Successfully built a0de4946268e
```

Note the successful build notification.

Thoughts, @nicolas33 ?