### PR TITLE
Communicate syncmode to synchooks

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -320,6 +320,9 @@ remoterepository = RemoteExample
 #
 # The pre sync script has to complete before a sync to the account will start.
 #
+# The environment variable OFFLINEIMAPSYNCMODE will be set to either full,
+# quick or idle to communicate the syncmode to the external command.
+#
 #presynchook = imapfilter -c someotherconfig.lua
 #postsynchook = notifysync.sh
 

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -832,10 +832,10 @@ class IdleThread:
         remotefolder = remoterepos.getfolder(self.folder, decode=False)
 
         hook = account.getconf('presynchook', '')
-        account.callhook(hook)
+        account.callhook(hook, "idle")
         offlineimap.accounts.syncfolder(account, remotefolder, quick=False)
         hook = account.getconf('postsynchook', '')
-        account.callhook(hook)
+        account.callhook(hook, "idle")
 
         ui = getglobalui()
         ui.unregisterthread(currentThread())  # syncfolder registered the thread


### PR DESCRIPTION
This patch sets the environment variable OFFLINEIMAPSYNCMODE to either
full, quick or idle depending on the context of the pre- and
postsynchook.

Adding the context as an argument was considered but this would break
existing configurations and it makes calling a program directly more
cumbersome. Some programs (e.g. imapfilter) may not know what to do with
this extra argument.

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- https://github.com/OfflineIMAP/offlineimap/issues/702

### Additional information


