### PR TITLE
Support for IMAPv4 ID extension

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -583,6 +583,11 @@ class IMAPServer:
                         af=self.af,
                     )
 
+                # If 'ID' extension is used by the server, we should use it
+                if 'ID' in imapobj.capabilities:
+                    l_str = '("name" "OfflineIMAP" "version" "{}")'.format(offlineimap.__version__)
+                    imapobj.id(l_str)
+
                 if not self.preauth_tunnel:
                     try:
                         self.__authn_helper(imapobj)


### PR DESCRIPTION
This patch enables the ID extension of IMAPv4.

The patch sends the client name and the client version to the server.

Usually, the server doesn't require it, but in some cases the server
drop de connection if the ID is not send.

#Close #71

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).



