### PR TITLE
Include offlineimap and pid in non interactive logs

### DIFF
--- a/offlineimap/ui/Noninteractive.py
+++ b/offlineimap/ui/Noninteractive.py
@@ -45,7 +45,7 @@ class Syslog(UIBase):
         # create syslog handler
         ch = logging.handlers.SysLogHandler('/dev/log')
         # create formatter and add it to the handlers
-        self.formatter = logging.Formatter("%(message)s")
+        self.formatter = logging.Formatter("offlineimap[%(process)d]: %(message)s")
         ch.setFormatter(self.formatter)
         # add the handlers to the logger
         self.logger.addHandler(ch)

--- a/offlineimap/ui/UIBase.py
+++ b/offlineimap/ui/UIBase.py
@@ -99,7 +99,7 @@ class UIBase:
         # create syslog handler
         ch = logging.handlers.SysLogHandler('/dev/log')
         # create formatter and add it to the handlers
-        self.formatter = logging.Formatter("%(message)s")
+        self.formatter = logging.Formatter("offlineimap[%(process)d]: %(message)s")
         ch.setFormatter(self.formatter)
         # add the handlers to the logger
         self.logger.addHandler(ch)


### PR DESCRIPTION
This patch includes the "offlineimap" string and the proccess id
in the output for non interactive logs and syslog logs.

Now, the output is something like this (syslog):

Oct 11 21:55:10 yangon offlineimap[635798]: Syncing foo: IMAP -> Maildir
Oct 11 21:55:10 yangon offlineimap[635798]: Syncing foo bar: IMAP -> Maildir
Oct 11 21:55:10 yangon offlineimap[635798]: Syncing INBOX: IMAP -> Maildir
Oct 11 21:55:10 yangon offlineimap[635798]: Syncing bar: IMAP -> Maildir
Oct 11 21:55:10 yangon offlineimap[635798]: Syncing Trash: IMAP -> Maildir

Closes #88

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #88 


