### PR TITLE
Introduced support of system keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Bugs, issues and contributions can be requested to both the mailing list or the
 * Python v3+
 * rfc6555 (required)
 * imaplib2 >= 3.5
+* keyring
 * gssapi (optional), for Kerberos authentication
 * portalocker (optional), if you need to run offlineimap in Cygwin for Windows
 

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -56,6 +56,8 @@ class IMAPServer:
         self.ui = getglobalui()
         self.repos = repos
         self.config = repos.getconfig()
+        self.ignore_keyring = self.config.getboolean('general', 'ignore-keyring')
+        self.update_keyring = self.config.getboolean('general', 'update-keyring')
 
         self.preauth_tunnel = repos.getpreauthtunnel()
         self.transport_tunnel = repos.gettransporttunnel()
@@ -176,8 +178,10 @@ class IMAPServer:
             return self.password  # non-failed preconfigured one
 
         # get 1) configured password first 2) fall back to asking via UI
-        self.password = self.repos.getpassword() or \
+        self.password = self.repos.getpassword(self.ignore_keyring) or \
                         self.ui.getpass(self.username, self.config, self.passworderror)
+        if self.update_keyring:
+            self.repos.updatepassword(self.password)
         self.passworderror = None
         return self.password
 

--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -196,6 +196,14 @@ class OfflineImap:
                           action="store_true", dest="mbnames_prune", default=False,
                           help="remove mbnames entries for accounts not in accounts")
 
+        parser.add_option("--ignore-keyring",
+                          action="store_true", dest="ignore_keyring", default=False,
+                          help="Ignore password which is stored in system keyring")
+
+        parser.add_option("--update-keyring",
+                          action="store_true", dest="update_keyring", default=False,
+                          help="Update system keyring with used password")
+
         (options, args) = parser.parse_args()
         glob.set_options(options)
 
@@ -272,6 +280,16 @@ class OfflineImap:
         if options.dryrun:
             config.set('general', 'dry-run', 'True')
         config.set_if_not_exists('general', 'dry-run', 'False')
+
+        # ignore_keyring? Set [general]ignore_keyring=True.
+        if options.ignore_keyring:
+            config.set('general', 'ignore-keyring', 'True')
+        config.set_if_not_exists('general', 'ignore-keyring', 'False')
+
+        # update_keyring? Set [general]update_keyring=True.
+        if options.update_keyring:
+            config.set('general', 'update-keyring', 'True')
+        config.set_if_not_exists('general', 'update-keyring', 'False')
 
         try:
             # Create the ui class.

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -568,7 +568,7 @@ class IMAPRepository(BaseRepository):
         """
         return self.getconfboolean('expunge', True)
 
-    def getpassword(self, ignore_keyring):
+    def getpassword(self, ignore_keyring=False):
         """Return the IMAP password for this repository.
 
         It tries to get passwords in the following order:
@@ -578,6 +578,7 @@ class IMAPRepository(BaseRepository):
         3. read password from file specified in Repository 'remotepassfile'
         4. read password from ~/.netrc
         5. read password from /etc/netrc
+        6. read password from keyring
 
         On success we return the password.
         If all strategies fail we return None."""
@@ -651,7 +652,7 @@ class IMAPRepository(BaseRepository):
                 if user is None or user == netrcentry[0]:
                     return netrcentry[2]
 
-        # 5. Read from keyring as the last option
+        # 6. Read password from keyring as the last option
         if not ignore_keyring:
             return keyring.get_password(self.gethost(), self.getuser())
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gssapi[kerberos]
 portalocker[cygwin]
 rfc6555
 distro;platform_system=="Linux" and python_version>"3.7"
-
+keyring
 imaplib2>=3.5
 urllib3~=1.25.9
 certifi~=2020.6.20


### PR DESCRIPTION
Here a simple way that allows to migrate password to system keyrgin, and use it to run offlineimap.

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

No references

### Additional information


