### PR TITLE
Update IMAP.py

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -243,15 +243,15 @@ class IMAPFolder(BaseFolder):
         a = self.getfullIMAPname()
         res_type, imapdata = imapobj.select(a, True, True)
 
+        if imapdata == [None] or imapdata[0] == b'0':
+            # Empty folder, no need to populate message list.
+            return None
+        
         # imaplib2 returns the type as string, like "OK" but
         # returns imapdata as list of bytes, like [b'0'] so we need decode it
         # to use the existing code
         imapdata = [x.decode('utf-8') for x in imapdata]
-
-        if imapdata == [None] or imapdata[0] == '0':
-            # Empty folder, no need to populate message list.
-            return None
-
+     
         conditions = []
         # 1. min_uid condition.
         if min_uid is not None:


### PR DESCRIPTION


### This PR

>Return before decoding items of imapdata, if imapdata is equal to None it cannot be decoded.

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (provide details).

### Additional information

- system/distribution (with version): Archlinux
- offlineimap version (offlineimap -V): offlineimap v8.0.0, imaplib2 v3.06, Python v3.10.2, OpenSSL 1.1.1m  14 Dec 2021
- Python version: Python 3.10
- CLI options: offlineimap -a work
- Configuration file (offlineimaprc):

```
[general]
accounts = personal, work

[Account personal]
localrepository = Local
remoterepository = Remote

[Account work]
localrepository = workLocal
remoterepository = workRemote

[Repository workLocal]
type = Maildir
localfolders = ~/work/Mail

[Repository workRemote]
type = IMAP
ssl = no
remotehost = localhost
remoteport = 1143
remoteuser = REDACTED
remotepass = REDACTED

[Repository Local]
type = IMAP
remotehost = REDACTED
remoteuser = REDACTED
remotepass = REDACTED
ssl = yes
sslcacertfile = /etc/ssl/certs/ca-certificates.crt

[Repository Remote]
type = IMAP
ssl = yes
remotehost = REDACTED
remoteuser = REDACTED
remotepass = REDACTED
sslcacertfile = /etc/ssl/certs/ca-certificates.crt
folderfilter = lambda foldername: foldername not in ['Spam']
```
- Logs, error
```
 ERROR: ERROR in syncfolder for work folder Sent: Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/offlineimap/accounts.py", line 653, in syncfolder
    remotefolder.cachemessagelist()
  File "/usr/lib/python3.10/site-packages/offlineimap/folder/IMAP.py", line 295, in cachemessagelist
    msgsToFetch = self._msgs_to_fetch(
  File "/usr/lib/python3.10/site-packages/offlineimap/folder/IMAP.py", line 255, in _msgs_to_fetch
    imapdata = [x.decode('utf-8') for x in imapdata]
  File "/usr/lib/python3.10/site-packages/offlineimap/folder/IMAP.py", line 255, in <listcomp>
    imapdata = [x.decode('utf-8') for x in imapdata]
AttributeError: 'NoneType' object has no attribute 'decode'

  'NoneType' object has no attribute 'decode'
```

Steps to reproduce the error

Unable to reproduce after archive old emails, the error happens using offlineimap as client of davmail gateway. The PR solves the error, **but the real issue is that some folders are reported as empty,  imapdata=[None], but they contain messages.**
