### PR TITLE
Allow filtering of folders with spaces

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -717,6 +717,9 @@ class IMAPRepository(BaseRepository):
             try:
                 for foldername in self.folderincludes:
                     try:
+                        # Folder names with spaces requires quotes
+                        if ' ' in foldername:
+                            foldername = '"' + foldername + '"'
                         imapobj.select(imaputil.utf8_IMAP(foldername),
                                        readonly=True)
                     except OfflineImapError as exc:


### PR DESCRIPTION
This patch adds support to filter folders with the space caracter.

When the folder includes spaces, the folder name must be quoted.
This commit is basically a copy-paste of commit 81bd57e4

Signed-off-by: Hubert Pineault <hpineault@riseup.net>

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Somewhat related to Issue #58 because it addresses the same problem in the code.

### Additional information

- system/distribution (with version): Archlinux
- offlineimap version (offlineimap -V): offlineimap v8.0.0, imaplib2 v3.06, Python v3.10.2, OpenSSL 1.1.1n  15 Mar 2022
- Python version: Python 3.10.2
- CLI options: offlineimap -a mygmail

**Configuration file (offlineimaprc):**
```
[general]
accounts = mygmail
# Systemd runs multiple offlineimap instances maxsyncaccounts
# should be set to 1
maxsyncaccounts = 1
# reduce write cycles for ssd
fsync = False
pythonfile = ~/.offlineimap/offlineimaprc.py

[Account GmailHub]
localrepository = mygmailLocal
remoterepository = mygmailRemote
quick = 10
postsynchook = mu-index.sh
utf8foldernames = yes

[Repository mygmailLocal]
type = Maildir
localfolders = ~/Mail/my.gmail@gmail.com
sep = ^
synclabels = no
sync_deletes = yes
nametrans = lambda foldername: re.sub ('Drafts', '[Gmail].Brouillons',
              re.sub ('Junk', '[Gmail].Spam',
              re.sub ('Sent', '[Gmail].Messages envoyés',
              re.sub ('INBOX', '[Gmail].Tous les messages',
              re.sub ('Trash', '[Gmail].Corbeille', foldername)))))
[Repository mygmailRemote]
type = Gmail
remoteuser = my.gmail
remotepasseval = get_pass("mygmail")
starttls = no
ssl = yes
sslcacertfile = /etc/ssl/certs/ca-certificates.crt
maxconnections = 3
holdconnectionopen = no
singlethreadperfolder = no
createfolders = True
sync_deletes = yes

nametrans = lambda foldername: re.sub ('Tous les messages', 'INBOX',
              re.sub ('Brouillons', 'Drafts',
              re.sub ('Spam', 'Junk',
              re.sub ('Messages envoyés', 'Sent',
              re.sub ('Corbeille', 'Trash',
              re.sub ('\[Gmail\]/', '', foldername))))))

folderfilter = lambda folder: not re.search('^\[Gmail\]|INBOX|Trash', folder)

folderincludes = ["[Gmail]/Tous les messages",
                  '[Gmail]/Brouillons',
                  '[Gmail]/Spam',
                  '[Gmail]/Messages envoyés',
                  '[Gmail]/Corbeille']
```

**Logs, error**

```
Account sync mygmail:
 *** Processing account mygmail
 Establishing connection to imap.gmail.com:993 (mygmailRemote)
 ERROR: While attempting to sync account 'mygmail'
  EXAMINE command error: BAD [b'Could not parse command']. Data: [Gmail]/Tous les messages
 *** Finished account 'mygmail' in 0:00
ERROR: Exceptions occurred during the run!
ERROR: While attempting to sync account 'mygmail'
  EXAMINE command error: BAD [b'Could not parse command']. Data: [Gmail]/Tous les messages

Traceback:
  File "/usr/lib/python3.10/site-packages/offlineimap/accounts.py", line 298, in syncrunner
    self.__sync()
  File "/usr/lib/python3.10/site-packages/offlineimap/accounts.py", line 374, in __sync
    remoterepos.getfolders()
  File "/usr/lib/python3.10/site-packages/offlineimap/repository/IMAP.py", line 720, in getfolders
    imapobj.select(imaputil.utf8_IMAP(foldername),
  File "/usr/lib/python3.10/site-packages/offlineimap/imaplibutil.py", line 58, in select
    result = super(UsefulIMAPMixIn, self).select(mailbox, readonly)
  File "/usr/lib/python3.10/site-packages/imaplib2/imaplib2.py", line 1082, in select
    self._deliver_exc(self.error, '%s command error: %s %s. Data: %.100s' % (name, typ, dat, mailbox), kw)
  File "/usr/lib/python3.10/site-packages/imaplib2/imaplib2.py", line 1496, in _deliver_exc
    raise exc(dat)
```

**Steps to reproduce**

Any filter for a folder including a space character will fail it the same error.

**Notes**

The problem was not present with offlineimap 7.3.4:
```
offlineimap -V
offlineimap v7.3.4, imaplib2 v2.101 (bundled), Python v2.7.18, OpenSSL 1.1.1l  24 Aug 2021
```

Issue #58 raise a similar problem with folder with spaces, but the PR fixing it doesn't make the correction for filtering. I just copy-pasted what was done PR #80 into the `getfolders()` function. 

This patch fixes the bug and I can sync my gmail account again. I didn't test for other providers with spaces in folder names.