### PR TITLE
fix imap4-utf-7 decoding errors

### DIFF
--- a/offlineimap/imaputil.py
+++ b/offlineimap/imaputil.py
@@ -403,19 +403,19 @@ def modified_unbase64(s):
 def utf7m_decode(binary: bytes) -> Tuple[str, int]:
     r = []
     decode = []
-    for c in binary.decode():
-        if c == '&' and not decode:
+    for c in binary:
+        if c == ord('&') and not decode:
             decode.append('&')
-        elif c == '-' and decode:
+        elif c == ord('-') and decode:
             if len(decode) == 1:
                 r.append('&')
             else:
                 r.append(modified_unbase64(''.join(decode[1:])))
             decode = []
         elif decode:
-            decode.append(c)
+            decode.append(chr(c))
         else:
-            r.append(c)
+            r.append(chr(c))
 
     if decode:
         r.append(modified_unbase64(''.join(decode[1:])))


### PR DESCRIPTION
```py
>>> import offlineimap.imaputil
>>> b'&g0l6Pw-'.decode('imap4-utf-7')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/ldata/src/offlineimap3/offlineimap/imaputil.py", line 406, in utf7m_decode
    for c in binary.decode():
AttributeError: 'memoryview' object has no attribute 'decode'
```

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References


### Additional information


