### PR TITLE
format exception using traceback.format_exception_only for error messages

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -689,7 +689,6 @@ class IMAPServer:
                             OfflineImapError.ERROR.CRITICAL)
                 except:
                     pass
-                    e.args[0][:35]
 
             # re-raise all other errors
             raise

--- a/offlineimap/ui/UIBase.py
+++ b/offlineimap/ui/UIBase.py
@@ -538,10 +538,11 @@ class UIBase:
                 exitstatus = 1
         while not self.exc_queue.empty():
             msg, exc, exc_traceback = self.exc_queue.get()
+            exc_str = "".join(traceback.format_exception_only(type(exc), exc))
             if msg:
-                self.warn("ERROR: %s\n  %s" % (msg, exc))
+                self.warn("ERROR: %s\n  %s" % (msg, exc_str))
             else:
-                self.warn("ERROR: %s" % exc)
+                self.warn("ERROR: %s" % exc_str)
             if exc_traceback:
                 self.warn("\nTraceback:\n%s" % "".join(
                     traceback.format_tb(exc_traceback)))


### PR DESCRIPTION
because many exceptions return empty strings for `str(exc)`, or lack
information (e.g. the exception name).

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


