### PR TITLE
Fix ConfigParser compatibilty

### DIFF
--- a/offlineimap/CustomConfig.py
+++ b/offlineimap/CustomConfig.py
@@ -23,7 +23,7 @@ from offlineimap.localeval import LocalEval
 
 class CustomConfigParser(ConfigParser):
     def __init__(self):
-        SafeConfigParser.__init__(self)
+        ConfigParser.__init__(self)
         self.localeval = None
 
     def getdefault(self, section, option, default, *args, **kwargs):

--- a/offlineimap/CustomConfig.py
+++ b/offlineimap/CustomConfig.py
@@ -17,11 +17,11 @@
 import os
 import re
 from sys import exc_info
-from configparser import SafeConfigParser, Error
+from configparser import ConfigParser, Error
 from offlineimap.localeval import LocalEval
 
 
-class CustomConfigParser(SafeConfigParser):
+class CustomConfigParser(ConfigParser):
     def __init__(self):
         SafeConfigParser.__init__(self)
         self.localeval = None


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [ ] I've read the [DCO](http://www.offlineimap.org/doc/dco.html). - no, my browser says the site is not safe
- [ ] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html) - no, as above
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [ ] Code is tested (provide details).

### References

https://github.com/python/cpython/pull/92503

### Additional information


