### PR TITLE
Skip parsing date after failing to parse the date

### DIFF
--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -396,13 +396,12 @@ class MaildirFolder(BaseFolder):
                     message_timestamp = self.get_message_date(
                         msg, 'Delivery-date')
             except Exception as e:
-                # This should never happen.
+                # Extracting the date has failed for some reason, such as it
+                # being in an invalid format.
                 from offlineimap.ui import getglobalui
-                datestr = self.get_message_date(msg)
                 ui = getglobalui()
-                ui.warn("UID %d has invalid date %s: %s\n"
-                        "Not using message timestamp as file prefix" %
-                        (uid, datestr, e))
+                ui.warn("UID %d has invalid date: %s\n"
+                        "Not using message timestamp as file prefix" % (uid, e))
                 # No need to check if message_timestamp is None here since it
                 # would be overridden by _gettimeseq.
         messagename = self.new_message_filename(uid, flags, date=message_timestamp)
@@ -414,14 +413,13 @@ class MaildirFolder(BaseFolder):
                 if date is not None:
                     os.utime(os.path.join(self.getfullname(), tmpname),
                              (date, date))
-            # In case date is wrongly so far into the future as to be > max
-            # int32.
             except Exception as e:
+                # Extracting the date has failed for some reason, such as it
+                # being in an invalid format.
                 from offlineimap.ui import getglobalui
-                datestr = self.get_message_date(msg)
                 ui = getglobalui()
-                ui.warn("UID %d has invalid date %s: %s\n"
-                        "Not changing file modification time" % (uid, datestr, e))
+                ui.warn("UID %d has invalid date: %s\n"
+                        "Not changing file modification time" % (uid, e))
 
         self.messagelist[uid] = self.msglist_item_initializer(uid)
         self.messagelist[uid]['flags'] = flags


### PR DESCRIPTION
### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #134

### Additional information

When `file_use_mail_timestamp` or `utime_from_header` are enabled,
OfflineIMAP tries to parse the Date header in the email.  If the header
is present but invalid -- it doesn't contain a valid date -- this will
cause email.message to raise an exception.  This is all fine.  However
when handling that exception, OfflineIMAP can't try to extract the date
again: it's clearly invalid, and raising the same exception a second
time while handling the first exception just causes the entire sync to
fail.

To avoid that happening, don't try to provide the invalid date string in
the error message.  Instead, just give the user the UID of the email
that triggered the exception, and the exception text.

Ideally we'd instead fix the code to actually extract the header value
and provide it in the error message, but Python's email.message module
doesn't provide an easy way to get the raw text of the Date header from
an `EmailMessage` object; it's possible using private variables like
`EmailMessage._headers`, or by parsing the email using a custom
`email.policy.EmailPolicy` object that disables the module's attempts to
coerce the header value to a `DateTime`.  However, a user should be able
to get the problematic Date header from the message directly anyway, so
it's not worth adding all that complexity for something that should be
rare and provides little value.

I've tested it against the mail sync that led to me raising #134.
