### PR TITLE
LocalStatusSQLite.py: version aware threadsafety check (fixes #136)

### DIFF
--- a/offlineimap/folder/LocalStatusSQLite.py
+++ b/offlineimap/folder/LocalStatusSQLite.py
@@ -17,7 +17,7 @@
 
 import os
 import sqlite3 as sqlite
-from sys import exc_info
+from sys import exc_info,version_info
 from threading import Lock
 from .Base import BaseFolder
 
@@ -75,6 +75,11 @@ class LocalStatusSQLiteFolder(BaseFolder):
         self.filename = os.path.join(self.getroot(), self.getfolderbasename())
 
         self._newfolder = False  # Flag if the folder is new.
+        """
+        sqlite threading mode must be 3 as of Python 3.11, checking against
+        1 for versions below Python 3.11 to sustain backwards compatibility.
+        """
+        self._threading_mode_const = 3 if version_info.minor >=11 else 1
 
         dirname = os.path.dirname(self.filename)
         if not os.path.exists(dirname):
@@ -102,9 +107,10 @@ class LocalStatusSQLiteFolder(BaseFolder):
             if self._in_transactions < 1:
                 self.connection.commit()
 
+
     def openfiles(self):
         # Make sure sqlite is in multithreading SERIALIZE mode.
-        assert sqlite.threadsafety == 1, 'Your sqlite is not multithreading safe.'
+        assert sqlite.threadsafety == self._threading_mode_const, 'Your sqlite is not multithreading safe.'
 
         with self._databaseFileLock.getLock():
             # Try to establish connection, no need for threadsafety in __init__.


### PR DESCRIPTION
### This PR

> fixes #136 in a version-aware way. We specifically want to check wether sqlite.threadsafety returns the integer constant for SERIALIZED mode; so the value returned has to be `3` for Python >= 3.11 and `1` for Python <=3.10 to not break backwards compatibility. 

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (provide details).

### References

- #136 talks about this issue
- #137 points into the right direction, even though it ignores the code comment that the check must check for serialize mode; as every mode except single threaded is allowed here.

### Additional information

This is an slightly improved version of the local hotfix I have commented as a diff in #137.
