### PR TITLE
imap: always use cached capabilities

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -602,11 +602,12 @@ class IMAPServer:
                 imapobj.enable_compression()
 
             # update capabilities after login, e.g. gmail serves different ones
-            typ, dat = imapobj.capability()
-            if dat != [None]:
-                # Get the capabilities and convert them to string from bytes
-                s_dat = [x.decode('utf-8') for x in dat[-1].upper().split()]
-                imapobj.capabilities = tuple(s_dat)
+            if imapobj.capabilities is None:
+                typ, dat = imapobj.capability()
+                if dat != [None]:
+                    # Get the capabilities and convert them to string from bytes
+                    s_dat = [x.decode('utf-8') for x in dat[-1].upper().split()]
+                    imapobj.capabilities = tuple(s_dat)
 
             if self.delim is None:
                 listres = imapobj.list(self.reference, '""')[1]


### PR DESCRIPTION
### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #138

### Additional information

`imapobj` has a function call `capability()` and a cached version of that `capabilities`. The call of function literally makes a command `CAPABILITY` to IMAP server and some IMAP server may limits the number of that command to one that leads to fail like:
```
 ERROR: While attempting to sync account 'Personal'
  imaplib2.imaplib2.IMAP4.abort: command: CAPABILITY => socket error: <class 'OSError'> - Too many read 0
```
