### PR TITLE
Find extra paths for default CA bundle through the SSL module if possible (Python 3.4+)

### DIFF
--- a/offlineimap/utils/distro_utils.py
+++ b/offlineimap/utils/distro_utils.py
@@ -72,17 +72,24 @@ def get_os_sslcertfile_searchpath():
     at all.
     """
     os_name = get_os_name()
-    location = __DEF_OS_LOCATIONS.get(os_name, [''])
+    location = __DEF_OS_LOCATIONS.get(os_name, [])
 
     try:
         import ssl
         verify_paths = ssl.get_default_verify_paths()
-        location += [os.getenv(verify_paths.openssl_cafile_env) or '']
-        location += [verify_paths.cafile or '']
+        cafile_by_envvar = os.getenv(verify_paths.openssl_cafile_env)
+        if cafile_by_envvar is not None:
+            location += [cafile_by_envvar]
+        cafile_resolved = verify_paths.cafile
+        if cafile_resolved is not None:
+            location += [cafile_resolved]
+        cafile_hardcoded = verify_paths.openssl_cafile
+        if cafile_hardcoded is not None:
+            location += [cafile_hardcoded]
     except AttributeError:
         pass
     finally:
-        if location.count('') == len(location):
+        if len(location) == 0:
             return None
 
     return location

--- a/offlineimap/utils/distro_utils.py
+++ b/offlineimap/utils/distro_utils.py
@@ -72,7 +72,18 @@ def get_os_sslcertfile_searchpath():
     at all.
     """
     os_name = get_os_name()
-    location = __DEF_OS_LOCATIONS.get(os_name, None)
+    location = __DEF_OS_LOCATIONS.get(os_name, [''])
+
+    try:
+        import ssl
+        verify_paths = ssl.get_default_verify_paths()
+        location += [os.getenv(verify_paths.openssl_cafile_env) or '']
+        location += [verify_paths.cafile or '']
+    except AttributeError:
+        pass
+    finally:
+        if location.count('') == len(location):
+            return None
 
     return location
 


### PR DESCRIPTION
For me at least, this changed from it from giving the message "ERROR: Default CA bundle was requested, but OfflineIMAP doesn't know any for your current operating system" to actually working.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (provide details).

### Additional information

Nothing really to add.  I was a bit undecided about the route to take.  It would make most sense to prefer getting the information through the SSL module, but I kept the dictionary first, as not to step on the toes of those who worked on that dictionary.  I suppose an advantage of the route I took is that the behavior won't change for users who are using a known OS, but it will work in more OSes that aren't in the dictionary.
