### PR TITLE
imap: fail with error if cannot honor proxy config

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -430,13 +430,23 @@ remoterepository = RemoteExample
 # This option stands in the [Account Test] section.
 #
 # Use proxy connection for this account. Useful to bypass the GFW in China.
+# This option requires PySocks package to be installed (via your system
+# package manager or via pip).
+#
 # To specify a proxy connection, join proxy type, host and port with colons.
-# Available proxy types are SOCKS5, SOCKS4, HTTP.
-# You also need to install PySocks through pip.
+#   * Available proxy types are SOCKS5, SOCKS4, HTTP.
+#   * The proxy address must be IPv4 (PySocks does not support IPv6 yet).
 #
-# Currently, this feature leaks DNS support.
+# To use the proxy option, the 'ipv6' option in the remote repository config
+# must be set to either 'yes' or 'no' (depending on the network connection
+# available to the IMAP server, not to the proxy). The 'ipv6' option cannot be
+# left unset, since AF_UNSPEC is supported only without proxy.
 #
-#proxy = SOCKS5:IP:9999
+# When using SOCKS5 or SOCKS4 with SOCKS4a extension, DNS requests are resolved
+# remotely through the proxy. However, some extra DNS requests are still leaked
+# due to calls to getaddrinfo() in the current implementation (Issue #189).
+#
+#proxy = SOCKS5:IP:1080
 
 
 # EXPERIMENTAL: This option stands in the [Account Test] section.
@@ -496,11 +506,9 @@ remoterepository = RemoteExample
 # (so as to be compatible with prior config files).
 # If that is specifically NOT desired, use authproxy = ''
 #
-# To specify a proxy connection, join proxy type, host and port with colons.
-# Available proxy types are SOCKS5, SOCKS4, HTTP.
-# You also need to install PySocks through pip or your distro package manager.
+# See important notes at the 'proxy' config option that also apply here.
 #
-#authproxy = SOCKS5:IP:9999
+#authproxy = SOCKS5:IP:1080
 
 
 [Repository LocalExample]
@@ -662,10 +670,10 @@ type = IMAP
 # AF_UNSPEC is used as a fallback (default).
 #
 # AF_INET6:
-#ipv6 = True
+#ipv6 = yes
 #
 # AF_INET:
-#ipv6 = False
+#ipv6 = no
 
 
 # These options stands in the [Repository RemoteExample] section.


### PR DESCRIPTION
Problem: The user might configure a proxy, but this this proxy is silently bypassed in the cases listed below. This breaks the user's privacy, since the connection to the IMAP server is leaked with the user's IP (confirmed leak with `netstat` showing connection to IMAP server, no connection to the proxy at all). The proxy is pypassed when:

 1. the user leaves the ipv6 config option unset
 2. the user makes an error in the proxy/authproxy config option
 3. the PySocks dependency is not installed

Cause for case 1: The code in imaplibutil.py in open_socket() (overriden imaplib2.IMPA4) that follows two different paths depending on the protocol (AF_UNSET vs AF_INIT or AF_INET6). In case of AF_UNSET, the code calls rfc6555.create_connection() which creates a new socket instead of using the existing proxied socket that was passed by the caller, thus bypassing the proxy.

Fix: raise an error in all cases when the proxy would not be honored, for Case 1 check the AF_UNSET, for Cases 2 and 3 change the warnings into errors fatal to that account processing.

Also, explain the requirement to set ipv6 option in the documentation for the proxy option in the config template file. Also, add some extra information about remote DNS request via proxy and that only IPv4 supported for proxy address. Also, change option values from True/False to yes/no for consistency with other options. Also, change example port to 1080, which is the standard port for a SOCKS proxy.

This commit does not fix the DNS request leaks from getaddrinfo() calls, tracked in Issue #189.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).


### References

Related Issue [#189](https://github.com/OfflineIMAP/offlineimap/issues/189)

### Additional information

Tested cases:

1. no ipv6 in config:

```
ERROR: Account 'xxx': cannot use proxy without protocol choice ('ipv6' config must be set to yes or no)
Traceback:
  ...
  File "/usr/lib/python3.11/site-packages/offlineimap/imapserver.py", line 133, in __init__
    self.proxied_socket = self._get_proxy('proxy', socket.socket)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/offlineimap/imapserver.py", line 154, in _get_proxy
    raise OfflineImapError("Account '%s': "
```

3. PySocks dependency not installed

```ERROR: Exceptions occurred during the run!
ERROR: Account 'xxx': cannot use proxy: PySocks not found: No module named 'socks'
Traceback:
  ...
  File "/usr/lib/python3.11/site-packages/offlineimap/imapserver.py", line 133, in __init__
    self.proxied_socket = self._get_proxy('proxy', socket.socket)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/offlineimap/imapserver.py", line 175, in _get_proxy
    six.reraise(OfflineImapError,
  ...
  File "/usr/lib/python3.11/site-packages/offlineimap/imapserver.py", line 167, in _get_proxy
    import socks
```

4. syntax error in config value:

```
ERROR: Exceptions occurred during the run!
ERROR: Account 'xxx': invalid 'proxy' config: 'SOCKS5:10.0.0.1:1080:44': too many values to unpack (expected 3
)
Traceback:
 ...
  File "/usr/lib/python3.11/site-packages/offlineimap/imapserver.py", line 181, in _get_proxy
    six.reraise(OfflineImapError,  
  ...
  File "/usr/lib/python3.11/site-packages/offlineimap/imapserver.py", line 168, in _get_proxy
    proxy_type, host, port = proxy.split(":")
```

Note: `next` branch is broken for me for unrelated reasons. I was able to test these specific error code paths on that branch, but the sync does not complete due to unrelated exceptions.
