### PR TITLE
check for imaplib2 v3 dep: use imaplib2.__version__

### DIFF
--- a/offlineimap/virtual_imaplib2.py
+++ b/offlineimap/virtual_imaplib2.py
@@ -24,8 +24,7 @@ this virtual_imaplib2 or we might go into troubles.
 
 DESC = None
 
-_SUPPORTED_RELEASE = 2
-_SUPPORTED_REVISION = 57
+_MIN_SUPPORTED_VER = (2, 57)
 
 try:
     # Try any imaplib2 in PYTHONPATH first. This allows both maintainers of
@@ -33,12 +32,13 @@ try:
     from imaplib2 import *
     import imaplib2 as imaplib
 
-    if (int(imaplib.__release__) < _SUPPORTED_RELEASE or
-            int(imaplib.__revision__) < _SUPPORTED_REVISION):
-        raise ImportError("The provided imaplib2 version '%s' is not supported"%
-            imaplib.__version__)
+    ver = tuple(map(int, imaplib.__version__.split('.')))
+    if ver[:len(_MIN_SUPPORTED_VER)] < _MIN_SUPPORTED_VER:
+        raise ImportError("The provided imaplib2 version '%s' is not supported"
+                          " (required >= %s)" % (imaplib.__version__,
+                          '.'.join(map(str, _MIN_SUPPORTED_VER))))
     DESC = "system"
-except (ImportError, NameError) as e:
+except (ImportError, NameError, AttributeError, IndexError) as e:
     try:
         from offlineimap.bundled_imaplib2 import *
         import offlineimap.bundled_imaplib2 as imaplib
@@ -51,5 +51,3 @@ except (ImportError, NameError) as e:
 # Upstream won't expose those literals to avoid erasing them with "import *" in
 # case they exist.
 __version__ = imaplib.__version__
-__release__ = imaplib.__release__
-__revision__ = imaplib.__revision__


### PR DESCRIPTION
Problem 1: Distro package failed to build when attempting to check the version of system-provided imaplib2
dependency.

Problem 2: the check that was done 'ver.major < MIN_MAJOR or ver.minor < MIN_REVISION' will not evaluate correctly when ver.major exceeds MIN_MAJOR, which now happened with imaplib2 v3.06.

Reason: imaplib2 v3 (v3.06) does not expose `__release__` and `__revision__` but only exposes `__version__`.

Fix: use imaplib2.__version__ instead, and generalize the check to an arbitrary version tuple. Also, remove __release__, __revision__ exports since they are unused.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### Additional information

Original failure that this PR fixes, with imaplib2 v3.06 (`python-imaplib2` 3.6-5  Arch package):

```==> Starting build()...
Traceback (most recent call last):
  File "/home/redfish/dev/offlineimap/src/offlineimap3-8.0.0/setup.py", line 26, in <module>
    import offlineimap
  File "/home/redfish/dev/offlineimap/src/offlineimap3-8.0.0/offlineimap/__init__.py", line 20, in <module>
    from offlineimap.init import OfflineImap
  File "/home/redfish/dev/offlineimap/src/offlineimap3-8.0.0/offlineimap/init.py", line 29, in <module>
    import offlineimap.virtual_imaplib2 as imaplib
  File "/home/redfish/dev/offlineimap/src/offlineimap3-8.0.0/offlineimap/virtual_imaplib2.py", line 36, in <module>
    if (int(imaplib.__release__) < _SUPPORTED_RELEASE or
            ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'imaplib2' has no attribute '__release__'
==> ERROR: A failure occurred in build().
```

Tested code paths by building distro package (Arch):

1. imaplib2 v3.06
2. imaplib2 v2.06 (manually edited installed file to set __version__ = '2.06')

Installation success in both cases. Since there's no output from this code, I confirmed that the code path of the nested try:except does happen  in Case 2 by introducing temporary error in that path and getting an exception.