### PR TITLE
Only use the distro package if needed

### DIFF
--- a/offlineimap/utils/distro_utils.py
+++ b/offlineimap/utils/distro_utils.py
@@ -6,12 +6,6 @@ Module that supports distribution-specific functions.
 import platform
 import os
 
-# linux_distribution deprecated in Python 3.7
-try:
-    from platform import linux_distribution
-except ImportError:
-    from distro import linux_distribution
-
 # For the former we will just return the value, for an iterable
 # we will walk through the values and will return the first
 # one that corresponds to the existing file.
@@ -50,6 +44,12 @@ def get_os_name():
     os_name = platform.system().lower()
 
     if os_name.startswith('linux'):
+        # linux_distribution deprecated in Python 3.7
+        try:
+            from platform import linux_distribution
+        except ImportError:
+            from distro import linux_distribution
+
         distro_name = linux_distribution()[0]
         if distro_name:
             os_name = os_name + "-%s" % distro_name.split()[0].lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 gssapi[kerberos]
 portalocker[cygwin]
 rfc6555
-distro
+distro;platform_system=="Linux" and python_version>"3.7"
 
 imaplib2>=3.5
 urllib3~=1.25.9


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [ ] Code is tested (provide details).

### References

None

### Additional information

Hopefully self-explanatory; there's no need to require the distro package if it's not actually going to be used!

I'm in the process of packaging OfflineIMAP for Cygwin; removing the dependency on having the distro package available will make that job a bit easier.