### PR TITLE
Handle exceptions thrown while getting message ID

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -24,7 +24,7 @@ from offlineimap import imaputil, imaplibutil, OfflineImapError
 from offlineimap import globals
 from imaplib2 import MonthNames
 from .Base import BaseFolder
-from email.errors import NoBoundaryInMultipartDefect
+from email.errors import HeaderParseError, NoBoundaryInMultipartDefect
 
 # Globals
 CRLF = '\r\n'
@@ -658,7 +658,10 @@ class IMAPFolder(BaseFolder):
         date = self.__getmessageinternaldate(msg, rtime)
 
         # Message-ID is handy for debugging messages.
-        msg_id = self.getmessageheader(msg, "message-id")
+        try:
+            msg_id = self.getmessageheader(msg, "message-id")
+        except (HeaderParseError, IndexError):
+            msg_id = None
         if not msg_id:
             msg_id = '[unknown message-id]'
 


### PR DESCRIPTION
Python's email library can throw both an IndexError as well as a HeaderParseError when the email has certain invalid data in the message ID. This prevents users with faulty emails from syncing. This change allows us to simply continue without a message ID as was intended in the code before anyway.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (I ran this with a local copy of the code without issues).

### References

- Issue #no_space

### Additional information
Closes #119.
I am wondering whether we should catch some more exceptions in similar cases and also fix things like #160 along the way.

