### PR TITLE
Import fcntl

### DIFF
--- a/offlineimap/imaplibutil.py
+++ b/offlineimap/imaplibutil.py
@@ -29,12 +29,9 @@ from offlineimap.ui import getglobalui
 from imaplib2 import IMAP4, IMAP4_SSL, InternalDate
 
 try:
-    import portalocker
+    import fcntl
 except:
-    try:
-        import fcntl
-    except:
-        pass  # Ok if this fails, we can do without.
+    pass  # Ok if this fails, we can do without.
 
 
 class UsefulIMAPMixIn:
@@ -147,11 +144,14 @@ class IMAP4_Tunnel(UsefulIMAPMixIn, IMAP4):
     def set_nonblocking(self, fd):
         """Mark fd as nonblocking"""
 
-        # get the file's current flag settings
-        fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-        # clear non-blocking mode from flags
-        fl = fl & ~os.O_NONBLOCK
-        fcntl.fcntl(fd, fcntl.F_SETFL, fl)
+        try:
+            # get the file's current flag settings
+            fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+            # clear non-blocking mode from flags
+            fl = fl & ~os.O_NONBLOCK
+            fcntl.fcntl(fd, fcntl.F_SETFL, fl)
+        except NameError:
+            pass  # fnctl not available. :(
 
     def read(self, size):
         """data = read(size)


### PR DESCRIPTION
imaplibutil does not use portalocker, so only try to import fcntl and try to use it.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- [115](https://github.com/OfflineIMAP/offlineimap3/issues/115)

### Additional information

This has now been reported in Debian also at https://bugs.debian.org/1057921 and is very easy to reproduce the failure.
This patch has been tested with the scenaio of https://bugs.debian.org/1057921.
