### PR TITLE
ignore broken message-id - catch the exception

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -658,9 +658,12 @@ class IMAPFolder(BaseFolder):
         date = self.__getmessageinternaldate(msg, rtime)
 
         # Message-ID is handy for debugging messages.
-        msg_id = self.getmessageheader(msg, "message-id")
-        if not msg_id:
-            msg_id = '[unknown message-id]'
+        try:
+            msg_id = self.getmessageheader(msg, "message-id")
+            if not msg_id:
+                msg_id = '[unknown message-id]'
+        except:
+            msg_id = '[broken message-id]'
 
         retry_left = 2  # succeeded in APPENDING?
         imapobj = self.imapserver.acquireconnection()


### PR DESCRIPTION
Hello,

during my sync I have found a few problems and I have created a few updates in the code.

This patch extends the check if message ID. If the message ID is somehow corrupted or unparsable, an exception is raised and offlineimap stops. With this update I propose to ignore message ID and set just some text similarly as in case if message ID is missing. With this update, the offlineimap does not stop on unparsable message ID.

Please, review this update if it's correct and please merge it if you find it useful. Otherwise update code or just close the PR.

Thank you.

Regards,
Robo.