### PR TITLE
use already defined function foldername_to_imapname() to quote folder name

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -734,10 +734,7 @@ class IMAPRepository(BaseRepository):
             try:
                 for foldername in self.folderincludes:
                     try:
-                        # Folder names with spaces requires quotes
-                        if ' ' in foldername:
-                            foldername = '"' + foldername + '"'
-                        imapobj.select(imaputil.utf8_IMAP(foldername),
+                        imapobj.select(imaputil.utf8_IMAP(imaputil.foldername_to_imapname(foldername)),
                                        readonly=True)
                     except OfflineImapError as exc:
                         # couldn't select this folderinclude, so ignore folder.
@@ -802,8 +799,7 @@ class IMAPRepository(BaseRepository):
         """Delete a folder on the IMAP server."""
 
         # Folder names with spaces requires quotes
-        if ' ' in foldername:
-            foldername = '"' + foldername + '"'
+        foldername = imaputil.foldername_to_imapname(foldername)
 
         if self.account.utf_8_support:
             foldername = imaputil.utf8_IMAP(foldername)
@@ -867,8 +863,7 @@ class IMAPRepository(BaseRepository):
         imapobj = self.imapserver.acquireconnection()
         try:
             # Folder names with spaces requires quotes
-            if ' ' in foldername:
-                foldername = '"' + foldername + '"'
+            foldername = imaputil.foldername_to_imapname(foldername)
 
             if self.account.utf_8_support:
                 foldername = imaputil.utf8_IMAP(foldername)


### PR DESCRIPTION
Hello,

during my sync I have found a few problems and I have created a few updates in the code.

This patch updates code with quoting folder name if it contains space. There is already function foldername_to_imapname which quotes foldername if it contains special symbol.

Please, review this update if it's correct and please merge it if you find it useful. Otherwise update code or just close the PR.

Thank you.

Regards,
Robo.
