### PR TITLE
Do not try to create existing folders

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -845,11 +845,12 @@ class IMAPRepository(BaseRepository):
         folder_paths = [self.getsep().join(parts[:n + 1])
                         for n in range(len(parts))]
         for folder_path in folder_paths:
-            try:
-                self.makefolder_single(folder_path)
-            except OfflineImapError as exc:
-                if '[ALREADYEXISTS]' not in exc.reason:
-                    raise
+            if not imaputil.foldername_to_imapname(folder_path) in [ f.getfullIMAPname() for f in self.getfolders() ] :
+                try:
+                    self.makefolder_single(folder_path)
+                except OfflineImapError as exc:
+                    if '[ALREADYEXISTS]' not in exc.reason:
+                        raise
 
     def makefolder_single(self, foldername):
         """
@@ -878,6 +879,9 @@ class IMAPRepository(BaseRepository):
                 msg = "Folder '%s'[%s] could not be created. "\
                       "Server responded: %s" % (foldername, self, str(result))
                 raise OfflineImapError(msg, OfflineImapError.ERROR.FOLDER)
+            else:
+                self.forgetfolders
+                self.getfolders
         finally:
             self.imapserver.releaseconnection(imapobj)
 

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -879,11 +879,11 @@ class IMAPRepository(BaseRepository):
                 msg = "Folder '%s'[%s] could not be created. "\
                       "Server responded: %s" % (foldername, self, str(result))
                 raise OfflineImapError(msg, OfflineImapError.ERROR.FOLDER)
-            else:
-                self.forgetfolders()
-                self.getfolders()
         finally:
             self.imapserver.releaseconnection(imapobj)
+            if result[0] == 'OK':
+                self.forgetfolders()
+                self.getfolders()
 
 
 class MappedIMAPRepository(IMAPRepository):

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -880,8 +880,8 @@ class IMAPRepository(BaseRepository):
                       "Server responded: %s" % (foldername, self, str(result))
                 raise OfflineImapError(msg, OfflineImapError.ERROR.FOLDER)
             else:
-                self.forgetfolders
-                self.getfolders
+                self.forgetfolders()
+                self.getfolders()
         finally:
             self.imapserver.releaseconnection(imapobj)
 


### PR DESCRIPTION
Hello,

during my sync I have found a few problems and I have created a few updates in the code.

This patch updates code of creating folders and folder structure. Some servers close connection are a few attempts to create already present folders. This update checks if the folder already exists and do not try to create it. And if the folder doesn't exist, it will be created and then the folder list will be updated for the next folder creating.

Please, review this update if it's correct and please merge it if you find it useful. Otherwise update code or just close the PR.

Thank you.

Regards,
Robo.
