### PR TITLE
Fldrname to imapname fix

### DIFF
--- a/offlineimap/imaputil.py
+++ b/offlineimap/imaputil.py
@@ -458,9 +458,9 @@ def foldername_to_imapname(folder_name):
 
     """
     # If name includes some of these characters, quote it
-    atom_specials = [' ', '/', '(', ')', '{', '}']
+    atom_specials = [' ', '/', '(', ')', '{', '}', '"']
 
     if any((c in atom_specials) for c in folder_name):
-        folder_name = '"' + folder_name + '"'
+        folder_name = self.quote(folder_name)
 
     return folder_name

--- a/offlineimap/imaputil.py
+++ b/offlineimap/imaputil.py
@@ -461,6 +461,6 @@ def foldername_to_imapname(folder_name):
     atom_specials = [' ', '/', '(', ')', '{', '}', '"']
 
     if any((c in atom_specials) for c in folder_name):
-        folder_name = self.quote(folder_name)
+        folder_name = quote(folder_name)
 
     return folder_name


### PR DESCRIPTION
Hello,

during my sync I have found a few problems and I have created a few updates in the code.

This patch updates code in `foldername_to_imapname()` function. This function should return folder name ready to be sent to IMAP server. It means, it should quote a folder name containing quotes `"` too. And it should escape quotes `"` and backslash `\` with a backslash symbol. Therefore it is used function `quote()`.

Please, review this update if it's correct and please merge it if you find it useful. Otherwise update code or just close the PR.

Thank you.

Regards,
Robo.
