### PR TITLE
convert tuple of octet count prefixed string (rfc3501, 4.3) to simple string

### DIFF
--- a/offlineimap/imaputil.py
+++ b/offlineimap/imaputil.py
@@ -108,6 +108,9 @@ def imapsplit(imapstring):
 
     ['(\\HasNoChildren)', '"."', '"INBOX.Sent"']"""
 
+    if isinstance(imapstring, tuple) and imapstring[0].decode("utf-8").rfind("{")>-1:
+        imapstring = (imapstring[0].decode("utf-8")[0:imapstring[0].decode("utf-8").rindex("{")] + imaputil.quote(imapstring[1].decode("utf-8"))).encode("utf-8")
+
     if not isinstance(imapstring, str):
         imapstring = imapstring.decode('utf-8')
 

--- a/offlineimap/imaputil.py
+++ b/offlineimap/imaputil.py
@@ -109,7 +109,7 @@ def imapsplit(imapstring):
     ['(\\HasNoChildren)', '"."', '"INBOX.Sent"']"""
 
     if isinstance(imapstring, tuple) and imapstring[0].decode("utf-8").rfind("{")>-1:
-        imapstring = (imapstring[0].decode("utf-8")[0:imapstring[0].decode("utf-8").rindex("{")] + imaputil.quote(imapstring[1].decode("utf-8"))).encode("utf-8")
+        imapstring = (imapstring[0].decode("utf-8")[0:imapstring[0].decode("utf-8").rindex("{")] + quote(imapstring[1].decode("utf-8"))).encode("utf-8")
 
     if not isinstance(imapstring, str):
         imapstring = imapstring.decode('utf-8')


### PR DESCRIPTION
Hello,

during my sync I have found a few problems and I have created a few updates in the code.

This patch updates code of `imapsplit()` function. If the IMAP server returns string as literal, the first line contains `{number}` and the next line is the folder name and the `number` is the length of folder name. The imapstring is then no simple string, instead it is a tuple with two strings. This update joins the two strings and quote the folder name. This type of string is called *literal* in the RFC3501 in section 4.3 and is described in section 9 as 

```
literal         = "{" number "}" CRLF *CHAR8
                    ; Number represents the number of CHAR8s
```

Please, review this update if it's correct and please merge it if you find it useful. Otherwise update code or just close the PR.

Thank you.

Regards,
Robo.
