### PR TITLE
Bugfix for imapserver.py

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -779,7 +779,11 @@ class IMAPServer:
             return  # Noop on bad connection.
 
         self.connectionlock.acquire()
-        self.assignedconnections.remove(connection)
+        try:
+            self.assignedconnections.remove(connection)
+        except ValueError:
+            self.connectionlock.release()
+            return
         # Don't reuse broken connections
         if connection.Terminate or drop_conn:
             connection.logout()


### PR DESCRIPTION
Handle releaseconnection getting called on a connection that is not in IMAPServer.assignedconnections

Signed-off-by: Matthew Rademaker <matthew.rademaker@gmail.com>

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

Tested on an outlook.com connection, bug went away and sync was successful.


