### PR TITLE
Add missing `keyring` dep in setup.py and pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,5 @@ requires = [
     "distro",
     "imaplib2>=3.5",
     "rfc6555",
+    "keyring"
 ]

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,5 @@ setup(name="offlineimap",
       scripts=['bin/offlineimap'],
       license=offlineimap.__copyright__ + ", Licensed under the GPL version 2",
       cmdclass={'test': TestCommand},
-      install_requires=['distro', 'imaplib2>=3.5', 'rfc6555', 'gssapi[kerberos]', 'portalocker[cygwin]', 'urllib3~=1.25.9']
+      install_requires=['distro', 'imaplib2>=3.5', 'rfc6555', 'gssapi[kerberos]', 'portalocker[cygwin]', 'urllib3~=1.25.9', 'keyring']
       )


### PR DESCRIPTION
### This PR

> Add missing `keyring` dep in setup.py and pyproject.toml.

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (`pip install --no-cache-dir -v git+https://github.com/tucksaun/offlineimap3.git@master` works successfully + GHA).

### References

### Additional information

[#102](https://github.com/OfflineIMAP/offlineimap3/pull/102) added support of system keyring and added `keyring` to `requirements.txt` but not in `setup.py` nor `pyproject.toml`. As a result the installation of offlineimap using pip `pip install --no-cache-dir -v git+https://github.com/OfflineIMAP/offlineimap3.git@master` does not work anymore.
Adding the missing dependency to those files fixes it.
