### PR TITLE
py3.12: allow config files with any extension

### DIFF
--- a/offlineimap/localeval.py
+++ b/offlineimap/localeval.py
@@ -28,6 +28,7 @@ class LocalEval:
         if path is not None:
             # FIXME: limit opening files owned by current user with rights set
             # to fixed mode 644.
+            importlib.machinery.SOURCE_SUFFIXES.append('') # empty string to allow any file
             spec = importlib.util.spec_from_file_location('<none>', path)
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)


### PR DESCRIPTION
importlib only allows importing files ending in .so or .py. This change is required to maintain backwards compatibility with paths with any filename

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).



