### PR TITLE
Make keyring support optional

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -23,8 +23,6 @@ import errno
 from sys import exc_info
 from threading import Event
 
-import keyring
-
 from offlineimap import folder, imaputil, imapserver, OfflineImapError
 from offlineimap.repository.Base import BaseRepository
 from offlineimap.threadutil import ExitNotifyThread
@@ -654,6 +652,7 @@ class IMAPRepository(BaseRepository):
 
         # 6. Read password from keyring as the last option
         if not ignore_keyring:
+            import keyring
             return keyring.get_password(self.gethost(), self.getuser())
         return None
 
@@ -662,6 +661,7 @@ class IMAPRepository(BaseRepository):
         This function update provided password into system keyring.
         None means to remove it.
         """
+        import keyring
         if password is None:
             keyring.delete_password(self.gethost(), self.getuser())
         else:

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,6 @@ setup(name="offlineimap",
       scripts=['bin/offlineimap'],
       license=offlineimap.__copyright__ + ", Licensed under the GPL version 2",
       cmdclass={'test': TestCommand},
-      install_requires=['distro', 'imaplib2>=3.5', 'rfc6555', 'gssapi[kerberos]', 'portalocker[cygwin]', 'urllib3~=1.25.9']
+      install_requires=['distro', 'imaplib2>=3.5', 'rfc6555', 'gssapi[kerberos]', 'portalocker[cygwin]', 'urllib3~=1.25.9'],
+      extras_require={'keyring': ['keyring']},
       )


### PR DESCRIPTION
Make support for the `keyring` module optional. This allows installing and using offlineimap without all the keyring-specific dependencies.

Note that offlineimap itself has only 7 dependencies, but keyring support requires an additional 12 dependencies.

For situations where keyring support is desirable, it can be installed by including the extra 'keyring':

    # the quotes are usually necessary due to shell expansions
    pip install 'offlineimap3[keyring]'

Or from this repository:

    pip install '.[keyring]'

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant information about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- No issue; mentioned in https://github.com/OfflineIMAP/offlineimap3/pull/102

### Additional information

This raises `ModuleNotFoundError` if the keyring is used but absent. Let me know if you think that showing an explicit message is worth the effort.