### PR TITLE
Use an underscore rather than a dash in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-from distutils.core import setup, Command
+from setuptools import setup, Command
 import offlineimap
 import logging
 from test.OLItest import TextTestRunner, TestLoader, OLITestLib

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,11 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-from setuptools import setup, Command
+try:
+    from setuptools import setup, Command
+except:
+    from distutils.core import setup, Command
+
 import offlineimap
 import logging
 from test.OLItest import TextTestRunner, TestLoader, OLITestLib


### PR DESCRIPTION
Prevents the error:
!!

        ********************************************************************************
        Usage of dash-separated 'description-file' will not be supported in future
        versions. Please use the underscore name 'description_file' instead.

        By 2024-Sep-26, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (provide details).