### PR TITLE
fix: "module importlib has no attribute 'machinery'"

### DIFF
--- a/offlineimap/localeval.py
+++ b/offlineimap/localeval.py
@@ -26,6 +26,8 @@ class LocalEval:
         self.namespace = {}
 
         if path is not None:
+            import importlib.machinery
+
             # FIXME: limit opening files owned by current user with rights set
             # to fixed mode 644.
             importlib.machinery.SOURCE_SUFFIXES.append('') # empty string to allow any file


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (tested with my backup scripts).

### References

- Issue #no_space

### Additional information

I'm no Python expert but it seems that `importlib.machinery` is only introduced in Python 3.3 so in order to maintain potential compatibility I added the import in the if clause just before it gets used. Let me know if you prefer if to be at the top of the file


