### PR TITLE
offlineimap.conf: use raw strings in regex examples

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -1229,12 +1229,12 @@ remoteuser = username
 # This example below will remove "INBOX." from the leading edge of folders
 # (great for Courier IMAP users).
 #
-#nametrans = lambda foldername: re.sub('^INBOX\.', '', foldername)
+#nametrans = lambda foldername: re.sub(r'^INBOX\.', '', foldername)
 #
 # Using Courier remotely and want to duplicate its mailbox naming locally?  Try
 # this:
 #
-#nametrans = lambda foldername: re.sub('^INBOX\.*', '.', foldername)
+#nametrans = lambda foldername: re.sub(r'^INBOX\.*', '.', foldername)
 
 
 # This option stands in the [Repository RemoteExample] section.
@@ -1267,7 +1267,7 @@ remoteuser = username
 # Example 3: Using a regular expression to exclude Trash and all folders
 # containing the characters "Del".
 #
-#folderfilter = lambda foldername: not re.search('(^Trash$|Del)', foldername)
+#folderfilter = lambda foldername: not re.search(r'(^Trash$|Del)', foldername)
 #
 # If folderfilter is not specified, ALL remote folders will be synchronized.
 #


### PR DESCRIPTION
Newer pythons are strict on the escape sequences allowed in normal strings, which can cause issues with regular expressions as most of them do include escape sequences that are not allowed. In those cases, the process will exit with the confusing warning:
  `<string>:1: SyntaxWarning: invalid escape sequence '\.'`

To help prevent such cases, have the sample configuration use raw strings when using regular expressions.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### Additional information

Tested with my own configuration which uses regular expressions with `\.` escaped.

