### PR TITLE
Fix DeprecationWarnings regex raw string and ConfigParser

### DIFF
--- a/test/OLItest/TestRunner.py
+++ b/test/OLItest/TestRunner.py
@@ -71,7 +71,7 @@ class OLITestLib:
         assert cls.cred_file is not None
         assert cls.testdir is not None
         config = CustomConfigParser()
-        config.readfp(default_conf)
+        config.read_file(default_conf)
         default_conf.seek(0)  # rewind config_file to start
         config.read(cls.cred_file)
         config.set("general", "metadata", cls.testdir)
@@ -234,7 +234,7 @@ Content here.''')
         return boxes, mails
 
     # find UID in a maildir filename
-    re_uidmatch = re.compile(',U=(\d+)')
+    re_uidmatch = re.compile(r',U=(\d+)')
 
     @classmethod
     def get_maildir_uids(cls, folder):


### PR DESCRIPTION
- Make regex a raw string.
- Use parser.read_file()

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).