### PR TITLE
docs/doc-src/conf.py: fix intersphinx_mapping config syntax

### DIFF
--- a/docs/doc-src/conf.py
+++ b/docs/doc-src/conf.py
@@ -198,4 +198,4 @@ latex_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = { 'http://docs.python.org/': ('https://docs.python.org/3', None) }


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (change is in the config for the documentation which was built successfully).

### References

- Issue #no_space

### Additional information


