### PR TITLE
Always pass an exception as first argument of ui.error

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -858,7 +858,9 @@ class IMAPFolder(BaseFolder):
                                    (e, uids, self.name, retry_num))
                         raise OfflineImapError(message,
                                                OfflineImapError.ERROR.MESSAGE)
-                    self.ui.error("%s. While fetching msg %r in folder %r."
+                    self.ui.error(e,
+                                  exc_info()[2],
+                                  "While fetching msg %r in folder %r."
                                   " Query: %s Retrying (%d/%d)" % (
                                       e, uids, self.name, query,
                                       retry_num - fails_left, retry_num))

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -258,7 +258,7 @@ class IMAPServer:
                 except Exception as eparams:
                     msg = "%s [cannot display configuration: %s]" % (e, eparams)
 
-                self.ui.error(msg)
+                self.ui.error(e, exc_info()[2], msg)
                 raise
             finally:
                 socket.socket = original_socket

--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -432,7 +432,7 @@ class OfflineImap:
             else:
                 errormsg = "Valid accounts are: %s" % (
                     ", ".join(allaccounts))
-                self.ui.error("The account '%s' does not exist" % accountname)
+                self.ui.error(ValueError("The account '%s' does not exist" % accountname))
 
         if len(activeaccounts) < 1:
             errormsg = "No accounts are defined!"
@@ -553,7 +553,7 @@ class OfflineImap:
     def __deletefolder(self, options):
         list_accounts = self._get_activeaccounts(options)
         if len(list_accounts) != 1:
-            self.ui.error("you must supply only one account with '-a'")
+            self.ui.error(ValueError("you must supply only one account with '-a'"))
             return 1
         account = accounts.Account(self.config, list_accounts.pop())
         return account.deletefolder(options.deletefolder)

--- a/offlineimap/mbnames.py
+++ b/offlineimap/mbnames.py
@@ -235,8 +235,10 @@ class _Mbnames:
                     for item in json.load(intermediateFD):
                         itemlist.append(item)
             except (OSError, IOError) as e:
-                self.ui.error("could not read intermediate mbnames file '%s':"
-                              "%s" % (intermediateFile, str(e)))
+                self.ui.error(e,
+                              exc_info()[2],
+                              "could not read intermediate mbnames file '%s'" %
+                              (intermediateFile))
             except Exception as e:
                 self.ui.error(
                     e,


### PR DESCRIPTION
Fix #233

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [ ] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


