### PR TITLE
Update distro_utils.py

### DIFF
--- a/offlineimap/utils/distro_utils.py
+++ b/offlineimap/utils/distro_utils.py
@@ -24,7 +24,12 @@ __DEF_OS_LOCATIONS = {
     'linux-ubuntu': ['/etc/ssl/certs/ca-certificates.crt'],
     'linux-debian': ['/etc/ssl/certs/ca-certificates.crt'],
     'linux-gentoo': ['/etc/ssl/certs/ca-certificates.crt'],
-    'linux-fedora': ['/etc/pki/tls/certs/ca-bundle.crt'],
+    'linux-fedora': [
+        # Through Fedora 43
+        '/etc/pki/tls/certs/ca-bundle.crt',
+        # Fedora 44 and after
+        '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
+    ],
     'linux-redhat': ['/etc/pki/tls/certs/ca-bundle.crt'],
     'linux-suse': ['/etc/ssl/ca-bundle.pem'],
     'linux-opensuse': ['/etc/ssl/ca-bundle.pem'],


### PR DESCRIPTION
Add relocated CA bundle for Fedora 44. I tested this on my machine running Fedora 44 beta with sslcacertfile = OS-DEFAULT and it works.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #237 

### Additional information


