### PR TITLE
Prevent deadlock in IMAPServer.close when using 'maxsyncaccounts' and 'maxconnections'.

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -158,6 +158,7 @@ class IMAPServer:
         self.lastowner = {}
         self.semaphore = BoundedSemaphore(self.maxconnections)
         self.connectionlock = Lock()
+        self.closing = False
         self.reference = repos.getreference()
         self.idlefolders = repos.getidlefolders()
         self.gss_vc = None
@@ -569,6 +570,11 @@ class IMAPServer:
 
         self.semaphore.acquire()
         self.connectionlock.acquire()
+        if self.closing:
+            self.connectionlock.release()
+            self.semaphore.release()
+            raise OfflineImapError("Server is closing",
+                                   OfflineImapError.ERROR.REPO)
         curThread = current_thread()
         imapobj = None
 
@@ -793,14 +799,17 @@ class IMAPServer:
         self.semaphore.release()
 
     def close(self):
+        # First make sure no new connections can be established.
+        self.connectionlock.acquire()
+        self.closing = True
+        self.connectionlock.release()
+
         # Make sure I own all the semaphores.  Let the threads finish
         # their stuff.  This is a blocking method.
+        # Make sure to not call this under connectionlock to avoid deadlocks.
+        threadutil.semaphorereset(self.semaphore, self.maxconnections)
+
         with self.connectionlock:
-            # first, wait till all connections had been released.
-            # TODO: won't work IMHO, as releaseconnection() also
-            # requires the connectionlock, leading to a potential
-            # deadlock! Audit & check!
-            threadutil.semaphorereset(self.semaphore, self.maxconnections)
             for imapobj in self.assignedconnections + self.availableconnections:
                 imapobj.logout()
             self.assignedconnections = []
@@ -809,6 +818,7 @@ class IMAPServer:
             # reset GSSAPI state
             self.gss_vc = None
             self.gssapi = False
+            self.closing = False
 
     def keepalive(self, timeout, event):
         """Sends a NOOP to each connection recorded.


### PR DESCRIPTION
We introduce a separate closing flag that's checked in acquireconnection, decoupling the connectionlock from the semaphore such that they can be acquired separately.

This is work towards getting rid of the 'maxsyncaccounts' / 'maxconnections' deprecation warning in the manual.

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (details below).

### References

- Issue #18, specifically, “offlineimap cannot acquire lock after system suspend”

### Additional information

I'm using this change in production with 'maxsyncaccounts' and 'maxconnections' both set to values > 1, as well as with autorefresh set. This change allows recovery from connection hangs after network changes (such as resuming after system suspend).
