### PR TITLE
Reevaluate oauth2_access_token_eval every time

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -144,7 +144,9 @@ class IMAPServer:
                             "the 'ssl_version' must be set explicitly.")
 
         self.oauth2_refresh_token = repos.getoauth2_refresh_token()
-        self.oauth2_access_token = repos.getoauth2_access_token()
+        self.oauth2_access_token_getter = repos.getoauth2_access_token_getter()
+        # is used if the above getter is None or doesn't work
+        self.oauth2_access_token = None
         self.oauth2_client_id = repos.getoauth2_client_id()
         self.oauth2_client_secret = repos.getoauth2_client_secret()
         self.oauth2_request_url = repos.getoauth2_request_url()
@@ -262,59 +264,65 @@ class IMAPServer:
 
     def __xoauth2handler(self, response):
         now = datetime.datetime.now()
-        if self.oauth2_access_token_expires_at \
-                and self.oauth2_access_token_expires_at < now:
-            self.oauth2_access_token = None
-            self.ui.debug('imap', 'xoauth2handler: oauth2_access_token expired')
+        access_token_to_use = None
+        if self.oauth2_access_token_getter is not None:
+            access_token_to_use = self.oauth2_access_token_getter()
 
-        if self.oauth2_access_token is None:
-            if self.oauth2_request_url is None:
-                raise OfflineImapError("No remote oauth2_request_url for "
-                                       "repository '%s' specified." %
-                                       self, OfflineImapError.ERROR.REPO)
+        if access_token_to_use is None:
+            if self.oauth2_access_token_expires_at \
+                    and self.oauth2_access_token_expires_at < now:
+                self.oauth2_access_token = None
+                self.ui.debug('imap', 'xoauth2handler: oauth2_access_token expired')
 
-            # Generate new access token.
-            params = {}
-            params['client_id'] = self.oauth2_client_id
-            params['client_secret'] = self.oauth2_client_secret
-            params['refresh_token'] = self.oauth2_refresh_token
-            params['grant_type'] = 'refresh_token'
+            if self.oauth2_access_token is None:
+                if self.oauth2_request_url is None:
+                    raise OfflineImapError("No remote oauth2_request_url for "
+                                           "repository '%s' specified." %
+                                           self, OfflineImapError.ERROR.REPO)
 
-            self.ui.debug('imap', 'xoauth2handler: url "%s"' %
-                          self.oauth2_request_url)
-            self.ui.debug('imap', 'xoauth2handler: params "%s"' % params)
+                # Generate new access token.
+                params = {}
+                params['client_id'] = self.oauth2_client_id
+                params['client_secret'] = self.oauth2_client_secret
+                params['refresh_token'] = self.oauth2_refresh_token
+                params['grant_type'] = 'refresh_token'
 
-            original_socket = socket.socket
-            socket.socket = self.authproxied_socket
-            try:
-                response = urllib.request.urlopen(
-                    self.oauth2_request_url, urllib.parse.urlencode(params).encode('utf-8')).read()
-            except Exception as e:
+                self.ui.debug('imap', 'xoauth2handler: url "%s"' %
+                              self.oauth2_request_url)
+                self.ui.debug('imap', 'xoauth2handler: params "%s"' % params)
+
+                original_socket = socket.socket
+                socket.socket = self.authproxied_socket
                 try:
-                    msg = "%s (configuration is: %s)" % (e, str(params))
-                except Exception as eparams:
-                    msg = "%s [cannot display configuration: %s]" % (e, eparams)
+                    response = urllib.request.urlopen(
+                        self.oauth2_request_url, urllib.parse.urlencode(params).encode('utf-8')).read()
+                except Exception as e:
+                    try:
+                        msg = "%s (configuration is: %s)" % (e, str(params))
+                    except Exception as eparams:
+                        msg = "%s [cannot display configuration: %s]" % (e, eparams)
 
-                self.ui.error(e, exc_info()[2], msg)
-                raise
-            finally:
-                socket.socket = original_socket
+                    self.ui.error(e, exc_info()[2], msg)
+                    raise
+                finally:
+                    socket.socket = original_socket
 
-            resp = json.loads(response)
-            self.ui.debug('imap', 'xoauth2handler: response "%s"' % resp)
-            if 'error' in resp:
-                raise OfflineImapError("xoauth2handler got: %s" % resp,
-                                       OfflineImapError.ERROR.REPO)
-            self.oauth2_access_token = resp['access_token']
-            if 'expires_in' in resp:
-                self.oauth2_access_token_expires_at = now + datetime.timedelta(
-                    seconds=resp['expires_in'] / 2
-                )
+                resp = json.loads(response)
+                self.ui.debug('imap', 'xoauth2handler: response "%s"' % resp)
+                if 'error' in resp:
+                    raise OfflineImapError("xoauth2handler got: %s" % resp,
+                                           OfflineImapError.ERROR.REPO)
+                self.oauth2_access_token = resp['access_token']
+                if 'expires_in' in resp:
+                    self.oauth2_access_token_expires_at = now + datetime.timedelta(
+                        seconds=resp['expires_in'] / 2
+                    )
+                access_token_to_use = self.oauth2_access_token
 
         self.ui.debug('imap', 'xoauth2handler: access_token "%s expires %s"' % (
-            self.oauth2_access_token, self.oauth2_access_token_expires_at))
+            access_token_to_use, self.oauth2_access_token_expires_at))
         auth_string = 'user=%s\1auth=Bearer %s\1\1' % (
-            self.username, self.oauth2_access_token)
+            self.username, access_token_to_use)
         # auth_string = base64.b64encode(auth_string)
         self.ui.debug('imap', 'xoauth2handler: returning "%s"' % auth_string)
         return auth_string
@@ -431,7 +439,7 @@ class IMAPServer:
 
     def __authn_xoauth2(self, imapobj):
         if self.oauth2_refresh_token is None \
-                and self.oauth2_access_token is None:
+                and self.oauth2_access_token_getter is None:
             return False
 
         imapobj.authenticate('XOAUTH2', self.__xoauth2handler)

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -441,22 +441,27 @@ class IMAPRepository(BaseRepository):
                 refresh_token = refresh_token.strip("\n")
         return refresh_token
 
-    def getoauth2_access_token(self):
+    def getoauth2_access_token_getter(self):
         """
-        Get the OAUTH2 access token from the configuration (oauth2_access_token)
+        Get a function evaluating the OAUTH2 access token from the configuration (oauth2_access_token_getter)
         If the access token is not found, then returns None.
+        If evaluating the returned functions failed, it will return None.
 
-        Returns: OAUTH2 access token (oauth2_access_token)
+        Returns: a function returning OAUTH2 access token (oauth2_access_token_getter)
 
         """
         access_token = self.getconf('oauth2_access_token', None)
-        if access_token is None:
-            access_token = self.localeval.eval(
-                self.getconf('oauth2_access_token_eval', "None")
-            )
+        if access_token is not None:
+            return lambda:access_token
+        access_token_eval = self.getconf('oauth2_access_token_eval', None)
+        if access_token_eval is None:
+            return None
+        def access_token_getter():
+            access_token = self.localeval.eval(access_token_eval)
             if access_token is not None:
                 access_token = access_token.strip("\n")
-        return access_token
+            return access_token
+        return access_token_getter
 
     def getoauth2_client_id(self):
         """


### PR DESCRIPTION
Before this, authentication will fail after the access token has expired, and if this is handled by an external program using oauth2_access_token_eval, offlineimap3 will be able to renew the token by itself. We should allow oauth2_access_token_eval to run in this case.

One might imagine that authentication needs to be reperformed for example because of bad internet, and that the token will therefore be refreshed unnecessarily. I believe most users of
oauth2_access_token_eval will use caching and that this will not be a big problem.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change. (I think)
- [x] Code is mostly tested (I have tested both plain authentication and oauth using oauth2_access_token_eval after this patch. I have not tested with oauth managed by offlineimap as I don't have a configuration using this).

### References

Nothing.

### Additional information
I need this patch to be able to share my access token with an smtp program (I can't use the built-in oauth functionality) at the same time as I use the IDLE functionality in this program (the program will be long-running).