### PR TITLE
Fix %-interpolation error

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -862,7 +862,7 @@ class IMAPFolder(BaseFolder):
                                   exc_info()[2],
                                   "While fetching msg %r in folder %r."
                                   " Query: %s Retrying (%d/%d)" % (
-                                      e, uids, self.name, query,
+                                      uids, self.name, query,
                                       retry_num - fails_left, retry_num))
                     # Release dropped connection, and get a new one.
                     self.imapserver.releaseconnection(imapobj, True)


### PR DESCRIPTION
9c352d7 (Always pass an exception as first argument of ui.error,
2026-04-01) rearranged some of the arguments to `ui.error` in
`folder/IMAP.py`, but while it removed one of the %-interpolation
entries in the string to be interpolated, it didn't remove the argument
in the interpolation tuple.  This leads to errors like the below:

      File "offlineimap/folder/IMAP.py", line 863, in _fetch_from_imap
        "While fetching msg %r in folder %r."
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        " Query: %s Retrying (%d/%d)" % (
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
            e, uids, self.name, query,
            ~~~~~~~~~~~~~~~~~~~~~~~~~~
            retry_num - fails_left, retry_num))
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    TypeError: %d format: a real number is required, not str

Remove the argument from the interpolation tuple that has now been
removed from the string, so the tuple parameters and string contents
match again.


### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### Additional information

Tested by applying the patch and re-running.  I now get the expected error message:

    ERROR: While fetching msg '15788' in folder 'To/PD'. Query: (X-GM-LABELS BODY.PEEK[]) Retrying (1/2)
