### PR TITLE
Standardise man page formatting and warnings

### DIFF
--- a/docs/offlineimap.txt
+++ b/docs/offlineimap.txt
@@ -303,8 +303,8 @@ will not protect you from active attacks, such as Man-In-The-Middle attacks
 which cause you to connect to the wrong server and pretend to be your mail
 server.
 +
-*DO NOT RELY ON STARTTLS AS A SAFE CONNECTION GUARANTEEING THE AUTHENTICITY OF
-YOUR IMAP SERVER!*
+WARNING: DO NOT RELY ON STARTTLS AS A SAFE CONNECTION GUARANTEEING THE
+AUTHENTICITY OF YOUR IMAP SERVER!
 
 * allow_nonstandard_capabilities
 +
@@ -318,8 +318,8 @@ enables a best-effort fallback: OfflineIMAP reuses the capabilities advertised
 before STARTTLS, removing `LOGINDISABLED`, so that authentication can continue
 over the (assumed) encrypted connection.
 +
-*WARNING: only enable this option when you have verified that TLS is actually
-established correctly.* If the server is not performing STARTTLS properly,
+WARNING: Only enable this option when you have verified that TLS is actually
+established correctly. If the server is not performing STARTTLS properly,
 enabling this option could cause credentials to be transmitted in plain text.
 +
 Default: `no`.

--- a/docs/offlineimap.txt
+++ b/docs/offlineimap.txt
@@ -264,8 +264,7 @@ Security and SSL
 By default, OfflineIMAP will connect using any method that 'openssl' supports,
 that is SSLv2, SSLv3, or TLSv1.
 
-Do note that SSLv2 is notoriously insecure and deprecated.  Unfortunately,
-python2 does not offer easy ways to disable SSLv2. It is recommended you test
+Do note that SSLv2 is notoriously insecure and deprecated. It is recommended you test
 your setup and make sure that the mail server does not use an SSLv2
 connection. Use e.g. "openssl s_client -host mail.server -port 443" to find
 out the connection that is used by default.

--- a/docs/offlineimap.txt
+++ b/docs/offlineimap.txt
@@ -24,8 +24,7 @@ Works with Python 3.
 OPTIONS
 -------
 
--h::
---help::
+-h, --help::
 
   Display summary of options.
 
@@ -107,16 +106,16 @@ included), implies the single-thread option `-1'.
 
 -l <path/to/file.log>::
 
-   Send logs to <file.log>.
+  Send logs to <file.log>.
 
 -s::
 
-   Send logs to syslog.
+  Send logs to syslog.
 
 
 -f <folder1[,folder1[,...]]>::
 
-    Only sync the specified folders.
+  Only sync the specified folders.
 +
 The folder names are the untranslated foldernames of the remote repository.
 This command-line option overrides any 'folderfilter' and 'folderincludes'
@@ -158,6 +157,7 @@ blinkenlights, machineui.
 
 
 --delete-folder::
+
   Delete a folder on the remote repository.
 +
 Only one account must be specified/configured for this feature to work or you
@@ -167,6 +167,7 @@ otherwise. E.g.: "Remote/folder/name".
 
 
 --migrate-fmd5-using-nametrans::
+
   Migrate FMD5 hashes from versions prior to 6.3.5.
 +
 The way that FMD5 hashes are calculated was changed in version 6.3.5 (now using
@@ -181,6 +182,7 @@ flag first.
 
 
 --mbnames-prune::
+
   Remove dangling entries for removed accounts or if mbnames is not enabled/used
   anymore.
 +

--- a/docs/offlineimap.txt
+++ b/docs/offlineimap.txt
@@ -121,7 +121,7 @@ The folder names are the untranslated foldernames of the remote repository.
 This command-line option overrides any 'folderfilter' and 'folderincludes'
 options in the configuration file.
 
--k <[section:]option=value::
+-k <[section:]option=value>::
 
   Override any configuration file option.
 +


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information

Standardised formatting, removed python 2 reference and improved warning visibility.
