### PR TITLE
accounts: report errors syncing as errors

### DIFF
--- a/offlineimap/accounts.py
+++ b/offlineimap/accounts.py
@@ -378,9 +378,9 @@ class SyncableAccount(Account):
                 remoterepos.getfolders()
             except OfflineImapError as e:
                 msg = f"Error while getting folders for repository "
-                msg += f"'{remoterepos.name}' of account '{self}': {e} - "
+                msg += f"'{remoterepos.name}' of account '{self}' - "
                 msg += "skipping account."
-                self.ui.warn(msg)
+                self.ui.error(e, exc_info()[2], msg=msg)
                 return  # Continue with next account.
 
             localrepos.getfolders()


### PR DESCRIPTION
As "just" a warning, monitoring can miss problems such as out-of-date SSL certificate chains or fingerprints.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>

---
As context, I have monitoring set up on my journal log and errors surface, but warnings are not. By raising this as an error, I can get notifications for errors syncing without also being inundated with warnings.

Tested by mucking with my fingerprint hashes and observing behavior in notifications.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).